### PR TITLE
Finish soundness

### DIFF
--- a/language_term_n2.lean
+++ b/language_term_n2.lean
@@ -1,3 +1,9 @@
+namespace tactic
+namespace interactive
+meta def congr1 : tactic unit := congr_core
+end interactive
+end tactic
+
 structure Language := 
 (relations : Π n : nat, Type) (functions : Π  n : nat, Type)
 section
@@ -11,16 +17,82 @@ inductive preterm : ℕ → Type
 open preterm
 def term := preterm 0
 
-/- raise_depth_term _ t n m raises variables in t which are at least m by n -/
-def raise_depth_term : ∀ {l}, preterm l → ℕ → ℕ → preterm l
-| _ (var L k) n m := if m ≤ k then var (k+m) else var k
-| _ (func f) n m := func f
-| _ (apply t1 t2) n m := apply (raise_depth_term t1 n m) (raise_depth_term t2 n m)
+/- lift_term _ t n m raises variables in t which are at least m by n -/
+@[simp] def lift_term : ∀ {l}, preterm l → ℕ → ℕ → preterm l
+| _ (var L k)     n m := if m ≤ k then var (k+n) else var k
+| _ (func f)      n m := func f
+| _ (apply t1 t2) n m := apply (lift_term t1 n m) (lift_term t2 n m)
+
+local notation [parsing_only] t ` ↑ `:55 n ` # `:55 m:55 := lift_term t n m
+
+lemma lift_term_inj : ∀ {l} {t t' : preterm l} {n m : ℕ}, t ↑ n # m = t' ↑ n # m → t = t'
+| _ (var L k) (var .(L) k')   n m h := 
+  by by_cases h₁ : m ≤ k; by_cases h₂ : m ≤ k'; simp [h₁, h₂] at h; congr; 
+       [exact add_right_cancel h, skip, skip, assumption]; exfalso; 
+       try {apply h₁}; try {apply h₂}; subst h; 
+       apply le_trans (by assumption) (nat.le_add_right _ _)
+| _ (var L k) (func f')       n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
+| _ (var L k) (apply t1' t2') n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
+| _ (func f) (var .(L) k')    n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
+| _ (func f) (func f')        n m h := h
+| _ (func f) (apply t1' t2')  n m h := by cases h
+| _ (apply t1 t2) (var _ k')  n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
+| _ (apply t1 t2) (func f')   n m h := by cases h
+| _ (apply t1 t2) (apply t1' t2') n m h := 
+  begin injection h, congr; apply lift_term_inj; assumption end
+
+@[simp] lemma lift_term_zero : ∀ {l} (t : preterm l) (m : ℕ), t ↑ 0 # m = t
+| _ (var L k)     m := by simp
+| _ (func f)      m := by refl
+| _ (apply t1 t2) m := by dsimp; congr; apply lift_term_zero
+
+/- the following lemmas simplify iterated lifts, depending on the size of m' -/
+lemma lift_term2_small : ∀ {l} (t : preterm l) (n n') {m m'}, m' ≤ m → 
+  (t ↑ n # m) ↑ n' # m' = (t ↑ n' # m') ↑ n # (m + n')
+| _ (var L k)     n n' m m' H := 
+  begin 
+    by_cases h : m ≤ k,
+    { have h₁ : m' ≤ k, from le_trans H h,
+      have h₂ : m' ≤ k + n, from le_trans h₁ (k.le_add_right n),
+      have h₃ : m + n' ≤ k + n', from add_le_add_right h _,
+      simp [h, h₁, h₂, h₃, -add_assoc, -add_comm], simp },
+    { have h₁ : ¬m + n' ≤ k + n', from λ h', h (le_of_add_le_add_right h'),
+      have h₂ : ¬m + n' ≤ k, from λ h', h₁ (le_trans h' (k.le_add_right n')),
+      by_cases h' : m' ≤ k; simp [h, h', h₁, h₂, -add_comm, -add_assoc], }
+  end
+| _ (func f)      n n' m m' H := by refl
+| _ (apply t1 t2) n n' m m' H := 
+  begin dsimp; congr1; apply lift_term2_small; assumption end
+
+lemma lift_term2_medium : ∀ {l} (t : preterm l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
+  (t ↑ n # m) ↑ n' # m' = t ↑ (n+n') # m
+| _ (var L k)     n n' m m' H₁ H₂ := 
+  begin 
+    by_cases h : m ≤ k,
+    { have h₁ : m' ≤ k + n, from le_trans H₂ (add_le_add_right h n),
+      simp [h, h₁, -add_comm], },
+    { simp[h, -add_assoc, -add_comm],
+      have h₁ : ¬m' ≤ k, from λ h', h (le_trans H₁ h'),
+      simp [h, h₁, -add_comm, -add_assoc] }
+  end
+| _ (func f)      n n' m m' H₁ H₂ := by refl
+| _ (apply t1 t2) n n' m m' H₁ H₂ := 
+  begin dsimp; congr1; apply lift_term2_medium; assumption end
+
+lemma lift_term2_eq {l} (t : preterm l) (n n' m : ℕ) : 
+  (t ↑ n # m) ↑ n' # (m+n) = t ↑ (n+n') # m :=
+lift_term2_medium t n n' (m.le_add_right n) (le_refl _)
+
+lemma lift_term2_large {l} (t : preterm l) (n n') {m m'} (H : m' ≥ m + n) : 
+  (t ↑ n # m) ↑ n' # m' = (t ↑ n' # m'-n) ↑ n # m :=
+have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
+have H₂ : m ≤ m' - n, by rw [←nat.add_sub_cancel m n]; apply nat.sub_le_sub_right; exact H,
+begin rw lift_term2_small t n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
 
 /- substitute_term t s n substitutes s for (var n) and reduces the level of all variables above n by 1 -/
-def substitute_term : ∀ {l}, preterm l → term → ℕ → preterm l
-| _ (var L k) s n := if k < n then var k else if k > n then var (k-1) else s
-| _ (func f) s n := func f
+@[simp] def substitute_term : ∀ {l}, preterm l → term → ℕ → preterm l
+| _ (var L k)     s n := if k < n then var k else if k > n then var (k-1) else s
+| _ (func f)      s n := func f
 | _ (apply t1 t2) s n := apply (substitute_term t1 s n) (substitute_term t2 s n)
 
 /- preformula n is a partially applied formula. if applied to n terms, it becomes a formula -/
@@ -34,20 +106,65 @@ inductive preformula : ℕ → Type
 open preformula
 def formula := preformula 0
 
-def raise_depth_formula : ∀ {l}, preformula l → ℕ → ℕ → preformula l
-| _ (false L) n m := false
-| _ (equal t1 t2) n m := equal (raise_depth_term t1 n m) (raise_depth_term t2 n m)
-| _ (rel R) n m := rel R
-| _ (apprel f t) n m := apprel (raise_depth_formula f n m) (raise_depth_term t n m)
-| _ (imp f1 f2) n m := imp (raise_depth_formula f1 n m) (raise_depth_formula f2 n m)
-| _ (all f) n m := all (raise_depth_formula f n (m+1))
+@[simp] def lift_formula : ∀ {l}, preformula l → ℕ → ℕ → preformula l
+| _ (false L)     n m := false
+| _ (equal t1 t2) n m := equal (lift_term t1 n m) (lift_term t2 n m)
+| _ (rel R)       n m := rel R
+| _ (apprel f t)  n m := apprel (lift_formula f n m) (lift_term t n m)
+| _ (imp f1 f2)   n m := imp (lift_formula f1 n m) (lift_formula f2 n m)
+| _ (all f)       n m := all (lift_formula f n (m+1))
 
-def substitute_formula : ∀ {l}, preformula l → term → ℕ → preformula l
-| _ (false L) s n := false
+local notation [parsing_only] f ` ↑ `:55 n ` # `:55 m:55 := lift_formula f n m
+
+@[simp] lemma lift_formula_zero : ∀ {l} (f : preformula l) (m : ℕ), f ↑ 0 # m = f
+| _ (false L)     m := by refl
+| _ (equal t1 t2) m := by simp
+| _ (rel R)       m := by refl
+| _ (apprel f t)  m := by simp; apply lift_formula_zero
+| _ (imp f1 f2)   m := by dsimp; congr1; apply lift_formula_zero
+| _ (all f)       m := by simp; apply lift_formula_zero
+
+/- the following lemmas simplify iterated lifts, depending on the size of m' -/
+lemma lift_formula2_small : ∀ {l} (f : preformula l) (n n') {m m'}, m' ≤ m → 
+  (f ↑ n # m) ↑ n' # m' = (f ↑ n' # m') ↑ n # (m + n')
+| _ (false L)     n n' m m' H := by refl
+| _ (equal t1 t2) n n' m m' H := by simp [lift_term2_small, H]
+| _ (rel R)       n n' m m' H := by refl
+| _ (apprel f t)  n n' m m' H := 
+  by simp [lift_term2_small, H, -add_comm]; apply lift_formula2_small; assumption
+| _ (imp f1 f2)   n n' m m' H := by dsimp; congr1; apply lift_formula2_small; assumption
+| _ (all f)       n n' m m' H :=
+  by simp [lift_term2_small, H, lift_formula2_small f n n' (add_le_add_right H 1)]
+
+lemma lift_formula2_medium : ∀ {l} (f : preformula l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
+  (f ↑ n # m) ↑ n' # m' = f ↑ (n+n') # m
+| _ (false L)     n n' m m' H₁ H₂ := by refl
+| _ (equal t1 t2) n n' m m' H₁ H₂ := by simp [lift_term2_medium, H₁, H₂]
+| _ (rel R)       n n' m m' H₁ H₂ := by refl
+| _ (apprel f t)  n n' m m' H₁ H₂ :=
+  by simp [lift_term2_medium, H₁, H₂, -add_comm]; apply lift_formula2_medium; assumption
+| _ (imp f1 f2)   n n' m m' H₁ H₂ := by dsimp; congr1; apply lift_formula2_medium; assumption
+| _ (all f)       n n' m m' H₁ H₂ :=
+  have m' + 1 ≤ (m + 1) + n, from le_trans (add_le_add_right H₂ 1) (by simp),
+  by simp [lift_term2_medium, H₁, H₂, lift_formula2_medium f n n' (add_le_add_right H₁ 1) this]
+
+lemma lift_formula2_eq {l} (f : preformula l) (n n' m : ℕ) : 
+  (f ↑ n # m) ↑ n' # (m+n) = f ↑ (n+n') # m :=
+lift_formula2_medium f n n' (m.le_add_right n) (le_refl _)
+
+lemma lift_formula2_large {l} (f : preformula l) (n n') {m m'} (H : m' ≥ m + n) : 
+  (f ↑ n # m) ↑ n' # m' = (f ↑ n' # m'-n) ↑ n # m :=
+have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
+have H₂ : m ≤ m' - n, by rw [←nat.add_sub_cancel m n]; apply nat.sub_le_sub_right; exact H,
+begin rw lift_formula2_small f n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
+
+@[simp] def substitute_formula : ∀ {l}, preformula l → term → ℕ → preformula l
+| _ (false L)     s n := false
 | _ (equal t1 t2) s n := equal (substitute_term t1 s n) (substitute_term t2 s n)
-| _ (rel R) s n := rel R
-| _ (apprel f t) s n := apprel (substitute_formula f s n) (substitute_term t s n)
-| _ (imp f1 f2) s n := imp (substitute_formula f1 s n) (substitute_formula f2 s n)
-| _ (all f) s n := all (substitute_formula f s (n+1))
+| _ (rel R)       s n := rel R
+| _ (apprel f t)  s n := apprel (substitute_formula f s n) (substitute_term t s n)
+| _ (imp f1 f2)   s n := imp (substitute_formula f1 s n) (substitute_formula f2 s n)
+| _ (all f)       s n := all (substitute_formula f s (n+1))
+
 
 end

--- a/language_term_n2.lean
+++ b/language_term_n2.lean
@@ -6,8 +6,24 @@
 * There is no well-formedness predicate; all elements of type "term" are well-formed.
 -/
 
--- depend on mathlib
---import data.list.basic
+-- this file depends on mathlib
+import data.list.basic algebra.ordered_group
+
+namespace nat
+lemma add_sub_swap {n k : ℕ} (h : k ≤ n) (m : ℕ) : n + m - k = n - k + m :=
+by rw [add_comm, nat.add_sub_assoc h, add_comm]
+
+lemma one_le_of_lt {n k : ℕ} (H : n < k) : 1 ≤ k :=
+succ_le_of_lt (lt_of_le_of_lt n.zero_le H)
+
+lemma add_sub_cancel_right (n m k : ℕ) : n + (m + k) - k = n + m :=
+by rw [nat.add_sub_assoc, nat.add_sub_cancel]; apply k.le_add_left
+
+end nat
+
+lemma {u} lt_by_cases {α : Type u} [linear_order α] (x y : α) {P : Prop}
+  (h₁ : x < y → P) (h₂ : x = y → P) (h₃ : y < x → P) : P :=
+or.elim (lt_trichotomy x y) h₁ (λh, or.elim h h₂ h₃)
 
 namespace tactic
 namespace interactive
@@ -15,20 +31,20 @@ meta def congr1 : tactic unit := congr_core
 end interactive
 end tactic
 
-open list
+open list nat
 namespace fol
 structure Language := 
 (relations : ℕ → Type) (functions : ℕ → Type)
 section
 parameter {L : Language}
 
-/- preterm n is a partially applied term. if applied to n terms, it becomes a term.
+/- preterm l is a partially applied term. if applied to n terms, it becomes a term.
 * Every element of preterm 0 is well typed. 
 * We use this encoding to avoid mutual or nested inductive types, since those are not too convenient to work with in Lean. -/
 inductive preterm : ℕ → Type 
 | var : ℕ → preterm 0
-| func : ∀ {n : nat}, L.functions n → preterm n
-| apply : ∀ {n : nat}, preterm (n + 1) → preterm 0 → preterm n
+| func : ∀ {l : nat}, L.functions l → preterm l
+| app : ∀ {l : nat}, preterm (l + 1) → preterm 0 → preterm l
 open preterm
 @[reducible] def term := preterm 0
 
@@ -36,111 +52,208 @@ prefix `&`:max := _root_.fol.preterm.var
 
 /- lift_term_at _ t n m raises variables in t which are at least m by n -/
 @[simp] def lift_term_at : ∀ {l}, preterm l → ℕ → ℕ → preterm l
-| _ &k            n m := if m ≤ k then &(k+n) else &k
-| _ (func f)      n m := func f
-| _ (apply t1 t2) n m := apply (lift_term_at t1 n m) (lift_term_at t2 n m)
+| _ &k          n m := if m ≤ k then &(k+n) else &k
+| _ (func f)    n m := func f
+| _ (app t1 t2) n m := app (lift_term_at t1 n m) (lift_term_at t2 n m)
 
-notation t ` ↑ `:100 n ` # `:100 m:100 := _root_.fol.lift_term_at t n m -- input ↑ with \upa
+notation t ` ↑ `:90 n ` # `:90 m:90 := _root_.fol.lift_term_at t n m -- input ↑ with \u or \upa
 
-def lift_term (t : term) (n : ℕ) : term := t ↑ n # 0
-def lift_term1 (t : term) : term := t ↑ 1 # 0
+@[reducible] def lift_term {l} (t : preterm l) (n : ℕ) : preterm l := t ↑ n # 0
+@[reducible] def lift_term1 (t : term) : term := t ↑ 1 # 0
 
 infix ` ↑↑ `:100 := _root_.fol.lift_term -- input ↑ with \upa
 postfix ` ↑1`:100 := _root_.fol.lift_term1 -- input ↑ with \upa
 
 lemma lift_term_at_inj : ∀ {l} {t t' : preterm l} {n m : ℕ}, t ↑ n # m = t' ↑ n # m → t = t'
 | _ &k &k' n m h := 
-  by by_cases h₁ : m ≤ k; by_cases h₂ : m ≤ k'; simp [h₁, h₂] at h; 
-     congr;[exact add_right_cancel h, skip, skip, assumption]; exfalso; try {apply h₁}; 
-     try {apply h₂}; subst h; apply le_trans (by assumption) (nat.le_add_right _ _)
-| _ &k (func f')              n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
-| _ &k (apply t1' t2')        n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
-| _ (func f) &k'              n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
-| _ (func f) (func f')        n m h := h
-| _ (func f) (apply t1' t2')  n m h := by cases h
-| _ (apply t1 t2) &k'         n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
-| _ (apply t1 t2) (func f')   n m h := by cases h
-| _ (apply t1 t2) (apply t1' t2') n m h := 
+  by by_cases h₁ : m ≤ k; by_cases h₂ : m ≤ k'; simp [h₁, h₂] at h;
+     congr;[assumption, skip, skip, assumption]; exfalso; try {apply h₁}; 
+     try {apply h₂}; subst h; apply le_trans (by assumption) (le_add_right _ _)
+| _ &k (func f')            n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
+| _ &k (app t1' t2')        n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
+| _ (func f) &k'            n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
+| _ (func f) (func f')      n m h := h
+| _ (func f) (app t1' t2')  n m h := by cases h
+| _ (app t1 t2) &k'         n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
+| _ (app t1 t2) (func f')   n m h := by cases h
+| _ (app t1 t2) (app t1' t2') n m h := 
   begin injection h, congr; apply lift_term_at_inj; assumption end
 
 @[simp] lemma lift_term_at_zero : ∀ {l} (t : preterm l) (m : ℕ), t ↑ 0 # m = t
-| _ &k            m := by simp
-| _ (func f)      m := by refl
-| _ (apply t1 t2) m := by dsimp; congr; apply lift_term_at_zero
+| _ &k          m := by simp
+| _ (func f)    m := by refl
+| _ (app t1 t2) m := by dsimp; congr; apply lift_term_at_zero
 
 /- the following lemmas simplify iterated lifts, depending on the size of m' -/
 lemma lift_term_at2_small : ∀ {l} (t : preterm l) (n n') {m m'}, m' ≤ m → 
   (t ↑ n # m) ↑ n' # m' = (t ↑ n' # m') ↑ n # (m + n')
-| _ &k            n n' m m' H := 
+| _ &k          n n' m m' H := 
   begin 
     by_cases h : m ≤ k,
     { have h₁ : m' ≤ k, from le_trans H h,
       have h₂ : m' ≤ k + n, from le_trans h₁ (k.le_add_right n),
-      have h₃ : m + n' ≤ k + n', from add_le_add_right h _,
-      simp [h, h₁, h₂, h₃, -add_assoc, -add_comm], simp },
+      simp [*, -add_assoc, -add_comm], simp },
     { have h₁ : ¬m + n' ≤ k + n', from λ h', h (le_of_add_le_add_right h'),
       have h₂ : ¬m + n' ≤ k, from λ h', h₁ (le_trans h' (k.le_add_right n')),
-      by_cases h' : m' ≤ k; simp [h, h', h₁, h₂, -add_comm, -add_assoc], }
+      by_cases h' : m' ≤ k; simp [*, -add_comm, -add_assoc], }
   end
-| _ (func f)      n n' m m' H := by refl
-| _ (apply t1 t2) n n' m m' H := 
+| _ (func f)    n n' m m' H := by refl
+| _ (app t1 t2) n n' m m' H := 
   begin dsimp; congr1; apply lift_term_at2_small; assumption end
 
-lemma lift_term_at2_medium : ∀ {l} (t : preterm l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
+lemma lift_term_at2_medium : ∀ {l} {t : preterm l} {n n' m m'}, m ≤ m' → m' ≤ m+n → 
   (t ↑ n # m) ↑ n' # m' = t ↑ (n+n') # m
-| _ &k            n n' m m' H₁ H₂ := 
+| _ &k          n n' m m' H₁ H₂ := 
   begin 
     by_cases h : m ≤ k,
     { have h₁ : m' ≤ k + n, from le_trans H₂ (add_le_add_right h n),
-      simp [h, h₁, -add_comm], },
-    { simp[h, -add_assoc, -add_comm],
+      simp [*, -add_comm], },
+    { simp [h, -add_assoc, -add_comm],
       have h₁ : ¬m' ≤ k, from λ h', h (le_trans H₁ h'),
-      simp [h, h₁, -add_comm, -add_assoc] }
+      simp [*, -add_comm, -add_assoc] }
   end
-| _ (func f)      n n' m m' H₁ H₂ := by refl
-| _ (apply t1 t2) n n' m m' H₁ H₂ := 
+| _ (func f)    n n' m m' H₁ H₂ := by refl
+| _ (app t1 t2) n n' m m' H₁ H₂ := 
   begin dsimp; congr1; apply lift_term_at2_medium; assumption end
+
+lemma lift_term2_medium {l} {t : preterm l} {n n' m'} (h : m' ≤ n) :
+  (t ↑↑ n) ↑ n' # m' = t ↑↑ (n+n') :=
+lift_term_at2_medium m'.zero_le (by simp*)
 
 lemma lift_term_at2_eq {l} (t : preterm l) (n n' m : ℕ) : 
   (t ↑ n # m) ↑ n' # (m+n) = t ↑ (n+n') # m :=
-lift_term_at2_medium t n n' (m.le_add_right n) (le_refl _)
+lift_term_at2_medium (m.le_add_right n) (le_refl _)
 
-lemma lift_term_at2_large {l} (t : preterm l) (n n') {m m'} (H : m' ≥ m + n) : 
+lemma lift_term_at2_large {l} (t : preterm l) (n n') {m m'} (H : m + n ≤ m') : 
   (t ↑ n # m) ↑ n' # m' = (t ↑ n' # (m'-n)) ↑ n # m :=
 have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
-have H₂ : m ≤ m' - n, by rw [←nat.add_sub_cancel m n]; apply nat.sub_le_sub_right; exact H,
+have H₂ : m ≤ m' - n, from nat.le_sub_right_of_add_le H,
 begin rw fol.lift_term_at2_small t n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
 
-/- substitute_term t s n substitutes s for (&n) and reduces the level of all variables above n by 1 -/
-@[simp] def substitute_term : ∀ {l}, preterm l → term → ℕ → preterm l
-| _ &k            s n := if k < n then &k else if n < k then &(k-1) else s
-| _ (func f)      s n := func f
-| _ (apply t1 t2) s n := apply (substitute_term t1 s n) (substitute_term t2 s n)
+/- subst_term t s n substitutes s for (&n) and reduces the level of all variables above n by 1 -/
+def subst_term : ∀ {l}, preterm l → term → ℕ → preterm l
+| _ &k          s n := if k < n then &k else if n < k then &(k-1) else s ↑↑ n
+| _ (func f)    s n := func f
+| _ (app t1 t2) s n := app (subst_term t1 s n) (subst_term t2 s n)
 
-notation t `[`:95 s ` // `:95 n `]`:0 := _root_.fol.substitute_term t s n
+notation t `[`:max s ` // `:95 n `]`:0 := _root_.fol.subst_term t s n
 
-@[simp] def substitute_term_var_eq (t : term) (n : ℕ) : &n[t // n] = t :=
-by simp [lt_irrefl]
+@[simp] lemma subst_term_var_lt (s : term) {k n : ℕ} (H : k < n) : &k[s // n] = &k :=
+by simp [subst_term, H]
 
-lemma substitute_term_lift_term' : ∀{l} (t : preterm l) (s : term) (n : ℕ), 
-  (lift_term_at t 1 n)[s // n] = t :=
-sorry
+@[simp] lemma subst_term_var_gt (s : term) {k n : ℕ} (H : n < k) : &k[s // n] = &(k-1) :=
+have h : ¬(k < n), from lt_asymm H,
+by simp [*, subst_term]
 
-@[simp] lemma substitute_term_lift_term (t s : term) : (lift_term1 t)[s // 0] = t :=
-substitute_term_lift_term' t s 0
+@[simp] lemma subst_term_var_eq (s : term) (n : ℕ) : &n[s // n] = s ↑ n # 0 :=
+by simp [subst_term, lt_irrefl]
 
-/- preformula n is a partially applied formula. if applied to n terms, it becomes a formula. 
+lemma subst_term_var0 (s : term) : &0[s // 0] = s := by simp
+
+@[simp] lemma subst_term_func {l} (f : L.functions l) (s : term) (n : ℕ) : 
+  (func f)[s // n] = func f :=
+by refl
+
+@[simp] lemma subst_term_app {l} (t₁ : preterm (l+1)) (t₂ s : term) (n : ℕ) : 
+  (app t₁ t₂)[s // n] = app (t₁[s // n]) (t₂[s // n]) :=
+by refl
+
+/- the following lemmas simplify first lifting and then substituting, depending on the size
+  of the substituted variable -/
+lemma lift_at_subst_term_large : ∀{l} (t : preterm l) (s : term) {n₁ n₂ m}, m ≤ n₁ →
+ (t ↑ n₂ # m)[s // n₁+n₂] = (t [s // n₁]) ↑ n₂ # m
+| _ &k          s n₁ n₂ m h :=
+  begin
+    apply lt_by_cases k n₁; intro h₂,
+    { have : k < n₁ + n₂, from lt_of_le_of_lt (k.le_add_right n₂) (by simp*),
+      by_cases m ≤ k; simp* },
+    { subst h₂, simp [*, lift_term2_medium] },
+    { have h₂ : m < k, by apply lt_of_le_of_lt; assumption,
+      have : m ≤ k - 1, from nat.le_sub_right_of_add_le (succ_le_of_lt h₂),
+      have : m ≤ k, from le_of_lt h₂,
+      have : 1 ≤ k, from one_le_of_lt h₂,
+      simp [*, nat.add_sub_swap this n₂, -add_assoc, -add_comm] }
+  end
+| _ (func f)    s n₁ n₂ m h := rfl
+| _ (app t1 t2) s n₁ n₂ m h := by simp*
+
+lemma lift_subst_term_large {l} (t : preterm l) (s : term) {n₁ n₂} :
+  (t ↑↑ n₂)[s // n₁+n₂] = (t [s // n₁]) ↑↑ n₂ :=
+lift_at_subst_term_large t s n₁.zero_le
+
+lemma lift_at_subst_term_medium : ∀{l} (t : preterm l) (s : term) {n₁ n₂ m}, m ≤ n₂ → 
+  n₂ ≤ m + n₁ → (t ↑ n₁+1 # m)[s // n₂] = t ↑ n₁ # m
+| _ &k          s n₁ n₂ m h₁ h₂ := 
+  begin 
+    by_cases h : m ≤ k,
+    { have h₂ : n₂ < k + (n₁ + 1), from lt_succ_of_le (le_trans h₂ (add_le_add_right h _)), 
+      simp [*, add_sub_cancel_right] },
+    { have h₂ : k < n₂, from lt_of_lt_of_le (lt_of_not_ge h) h₁, simp* }
+  end
+| _ (func f)    s n₁ n₂ m h₁ h₂ := rfl
+| _ (app t1 t2) s n₁ n₂ m h₁ h₂ := by simp*
+
+lemma lift_subst_term_medium {l} (t : preterm l) (s : term) {n₁ n₂} :
+  (t ↑↑ ((n₁ + n₂) + 1))[s // n₂] = t ↑↑ (n₁ + n₂) :=
+lift_at_subst_term_medium t s n₂.zero_le (by rw [zero_add]; exact n₂.le_add_left n₁)
+
+lemma lift_at_subst_term_eq {l} (t : preterm l) (s : term) (n : ℕ) : (t ↑ 1 # n)[s // n] = t :=
+begin rw [lift_at_subst_term_medium t s, lift_term_at_zero]; refl end
+
+@[simp] lemma lift_term1_subst_term (t s : term) : (lift_term1 t)[s // 0] = t :=
+lift_at_subst_term_eq t s 0
+
+lemma subst_term2 : ∀{l} (t : preterm l) (s₁ s₂ : term) (n₁ n₂),
+  t [s₁ // n₁] [s₂ // n₁ + n₂] = t [s₂ // n₁ + n₂ + 1] [s₁[s₂ // n₂] // n₁]
+| _ &k          s₁ s₂ n₁ n₂ :=
+  begin
+    apply lt_by_cases k n₁; intro h,
+    { have : k < n₁ + n₂, from lt_of_le_of_lt (k.le_add_right n₂) (by simp*),
+      have : k < n₁ + n₂ + 1, from lt.step this,
+      simp [*, -add_comm, -add_assoc] },
+    { have : k < k + (n₂ + 1), from lt_succ_of_le (le_add_right _ n₂),
+      subst h, simp [*, -add_comm], refine eq.trans _ (lift_subst_term_large _ _),
+      rw [add_comm] },
+    apply lt_by_cases k (n₁ + n₂ + 1); intro h',
+    { have : k - 1 < n₁ + n₂, from (nat.sub_lt_right_iff_lt_add (one_le_of_lt h)).2 h', 
+      simp [*, -add_comm, -add_assoc] },
+    { subst h', simp [h, -add_comm, -add_assoc], symmetry, apply lift_at_subst_term_medium,
+      apply n₁.zero_le, rw [zero_add], apply n₁.le_add_right },
+    { have : n₁ + n₂ < k - 1, from nat.lt_sub_right_of_add_lt h', 
+      have : n₁ < k - 1, from lt_of_le_of_lt (n₁.le_add_right n₂) this,
+      simp [*, -add_comm, -add_assoc] }
+  end
+| _ (func f)    s₁ s₂ n₁ n₂ := rfl
+| _ (app t1 t2) s₁ s₂ n₁ n₂ := by simp*
+
+
+lemma subst_term2_0 {l} (t : preterm l) (s₁ s₂ : term) (n) :
+  t [s₁ // 0] [s₂ // n] = t [s₂ // n + 1] [s₁[s₂ // n] // 0] :=
+let h := subst_term2 t s₁ s₂ 0 n in by simp at h; exact h
+
+/- Probably useful facts about substitution which we should add when needed:
+(forall M N i j k, ( M [ j ← N] ) ↑ k # (j+i) = (M ↑ k # (S (j+i))) [ j ← (N ↑ k # i ) ])
+
+
+subst_travers : (forall M N P n, (M [← N]) [n ← P] = (M [n+1 ← P])[← N[n← P]])
+erasure_lem1 : (forall a n, a = (a ↑ 1 # (S n)) [n ← #0])
+erasure_lem3 : (forall n m t, m>n->#m = (#m ↑ 1 # (S n)) [n ← t]). 
+lift_is_lift_sublemma : forall j v, j<v->exists w,#v=w↑1#j. 
+lift_is_lift : (forall N A n i j,N ↑ i # n=A ↑ 1 # j -> j<n -> exists M,N=M ↑ 1 # j)
+subst_is_lift : (forall N T A n j, N [n ← T]=A↑ 1#j->j<n->exists M,N=M↑ 1#j)
+-/
+
+/- preformula l is a partially applied formula. if applied to n terms, it becomes a formula. 
   * We only have implication as binary connective. Since we use classical logic, we can define
     the other connectives from implication and false. 
   * Similarly, universal quantification is our only quantifier. 
   * We could make `false` and `equal` into elements of rel. However, if we do that, then we cannot make the interpretation of them in a model definitionally what we want.
-
 -/
 inductive preformula : ℕ → Type 
 | false : preformula 0
 | equal : term → term → preformula 0
-| rel : ∀ {n : nat}, L.relations n → preformula n
-| apprel : ∀ {n : nat}, preformula (n + 1) → term → preformula n
+| rel : ∀ {l : nat}, L.relations l → preformula l
+| apprel : ∀ {l : nat}, preformula (l + 1) → term → preformula l
 | imp : preformula 0 → preformula 0 → preformula 0
 | all : preformula 0 → preformula 0
 open preformula
@@ -153,25 +266,33 @@ def iff (f₁ f₂ : formula) : formula := and (imp f₁ f₂) (imp f₂ f₁)
 def ex (f : formula) : formula := not (all (not f))
 
 notation `⊥` := _root_.fol.preformula.false -- input: \bot
-infix ` ≃ `:90 := _root_.fol.preformula.equal -- input \~- or \simeq
-infix ` ⟹ `:70 := _root_.fol.preformula.imp -- input \==>
-prefix `~` := _root_.fol.not
-infixr ` ⊔ `:80 := _root_.fol.or -- input: \sqcup
-infixr ` ⊓ `:85 := _root_.fol.and -- input: \sqcap
-
+infix ` ≃ `:88 := _root_.fol.preformula.equal -- input \~- or \simeq
+infix ` ⟹ `:62 := _root_.fol.preformula.imp -- input \==>
+prefix `∼`:max := _root_.fol.not -- input \~
+prefix [parsing_only] `~` := _root_.fol.not -- this is the ASCII character. warning: this has a way too low precedence. Use \~ for an operation with a good precedence.
+infixr ` ⊔ ` := _root_.fol.or -- input: \sqcup
+infixr ` ⊓ ` := _root_.fol.and -- input: \sqcap
+prefix `∀∀`:110 := _root_.fol.preformula.all
+prefix `∃∃`:110 := _root_.fol.ex
 
 @[simp] def lift_formula_at : ∀ {l}, preformula l → ℕ → ℕ → preformula l
 | _ false        n m := false
 | _ (t1 ≃ t2)    n m := equal (lift_term_at t1 n m) (lift_term_at t2 n m)
 | _ (rel R)      n m := rel R
 | _ (apprel f t) n m := apprel (lift_formula_at f n m) (lift_term_at t n m)
-| _ (imp f1 f2)  n m := imp (lift_formula_at f1 n m) (lift_formula_at f2 n m)
-| _ (all f)      n m := all (lift_formula_at f n (m+1))
+| _ (f1 ⟹ f2)   n m := lift_formula_at f1 n m ⟹ lift_formula_at f2 n m
+| _ (∀∀ f)       n m := ∀∀ lift_formula_at f n (m+1)
 
-notation f ` ↑ `:100 n ` # `:100 m:100 := _root_.fol.lift_formula_at f n m -- input ↑ with \upa
+notation f ` ↑ `:90 n ` # `:90 m:90 := _root_.fol.lift_formula_at f n m -- input ↑ with \upa
 
-def lift_formula (f : formula) (n : ℕ) : formula := f ↑ n # 0
-def lift_formula1 (f : formula) : formula := f ↑ 1 # 0
+@[reducible] def lift_formula {l} (f : preformula l) (n : ℕ) : preformula l := f ↑ n # 0
+@[reducible] def lift_formula1 (f : formula) : formula := f ↑ 1 # 0
+
+infix ` ↑↑ `:100 := _root_.fol.lift_formula -- input ↑ with \upa
+postfix ` ↑1`:100 := _root_.fol.lift_formula1 -- input ↑ with \upa
+
+@[simp] lemma lift_formula1_not (f : formula) : lift_formula1 (not f) = not (lift_formula1 f) :=
+by refl
 
 lemma lift_formula_at_inj {l} {f f' : preformula l} {n m : ℕ} (H : f ↑ n # m = f' ↑ n # m) : f = f' :=
 begin
@@ -187,8 +308,8 @@ end
 | _ (t1 ≃ t2)    m := by simp
 | _ (rel R)      m := by refl
 | _ (apprel f t) m := by simp; apply lift_formula_at_zero
-| _ (imp f1 f2)  m := by dsimp; congr1; apply lift_formula_at_zero
-| _ (all f)      m := by simp; apply lift_formula_at_zero
+| _ (f1 ⟹ f2)   m := by dsimp; congr1; apply lift_formula_at_zero
+| _ (∀∀ f)       m := by simp; apply lift_formula_at_zero
 
 /- the following lemmas simplify iterated lifts, depending on the size of m' -/
 lemma lift_formula_at2_small : ∀ {l} (f : preformula l) (n n') {m m'}, m' ≤ m → 
@@ -198,21 +319,19 @@ lemma lift_formula_at2_small : ∀ {l} (f : preformula l) (n n') {m m'}, m' ≤ 
 | _ (rel R)      n n' m m' H := by refl
 | _ (apprel f t) n n' m m' H := 
   by simp [lift_term_at2_small, H, -add_comm]; apply lift_formula_at2_small; assumption
-| _ (imp f1 f2)  n n' m m' H := by dsimp; congr1; apply lift_formula_at2_small; assumption
-| _ (all f)      n n' m m' H :=
+| _ (f1 ⟹ f2)   n n' m m' H := by dsimp; congr1; apply lift_formula_at2_small; assumption
+| _ (∀∀ f)       n n' m m' H :=
   by simp [lift_term_at2_small, H, lift_formula_at2_small f n n' (add_le_add_right H 1)]
 
 lemma lift_formula_at2_medium : ∀ {l} (f : preformula l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
   (f ↑ n # m) ↑ n' # m' = f ↑ (n+n') # m
 | _ false        n n' m m' H₁ H₂ := by refl
-| _ (t1 ≃ t2)    n n' m m' H₁ H₂ := by simp [lift_term_at2_medium, H₁, H₂]
+| _ (t1 ≃ t2)    n n' m m' H₁ H₂ := by simp [*, lift_term_at2_medium]
 | _ (rel R)      n n' m m' H₁ H₂ := by refl
-| _ (apprel f t) n n' m m' H₁ H₂ :=
-  by simp [lift_term_at2_medium, H₁, H₂, -add_comm]; apply lift_formula_at2_medium; assumption
-| _ (imp f1 f2)  n n' m m' H₁ H₂ := by dsimp; congr1; apply lift_formula_at2_medium; assumption
-| _ (all f)      n n' m m' H₁ H₂ :=
-  have m' + 1 ≤ (m + 1) + n, from le_trans (add_le_add_right H₂ 1) (by simp),
-  by simp [lift_term_at2_medium, H₁, H₂, lift_formula_at2_medium f n n' (add_le_add_right H₁ 1) this]
+| _ (apprel f t) n n' m m' H₁ H₂ := by simp [*, lift_term_at2_medium, -add_comm]
+| _ (f1 ⟹ f2)   n n' m m' H₁ H₂ := by simp*
+| _ (∀∀ f)       n n' m m' H₁ H₂ :=
+  have m' + 1 ≤ (m + 1) + n, from le_trans (add_le_add_right H₂ 1) (by simp), by simp*
 
 lemma lift_formula_at2_eq {l} (f : preformula l) (n n' m : ℕ) : 
   (f ↑ n # m) ↑ n' # (m+n) = f ↑ (n+n') # m :=
@@ -221,24 +340,52 @@ lift_formula_at2_medium f n n' (m.le_add_right n) (le_refl _)
 lemma lift_formula_at2_large {l} (f : preformula l) (n n') {m m'} (H : m' ≥ m + n) : 
   (f ↑ n # m) ↑ n' # m' = (f ↑ n' # (m'-n)) ↑ n # m :=
 have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
-have H₂ : m ≤ m' - n, by rw [←nat.add_sub_cancel m n]; apply nat.sub_le_sub_right; exact H,
+have H₂ : m ≤ m' - n, from nat.le_sub_right_of_add_le H,
 begin rw fol.lift_formula_at2_small f n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
 
-@[simp] def substitute_formula : ∀ {l}, preformula l → term → ℕ → preformula l
+@[simp] def subst_formula : ∀ {l}, preformula l → term → ℕ → preformula l
 | _ false        s n := false
-| _ (t1 ≃ t2)    s n := equal (substitute_term t1 s n) (substitute_term t2 s n)
+| _ (t1 ≃ t2)    s n := subst_term t1 s n ≃ subst_term t2 s n
 | _ (rel R)      s n := rel R
-| _ (apprel f t) s n := apprel (substitute_formula f s n) (substitute_term t s n)
-| _ (imp f1 f2)  s n := imp (substitute_formula f1 s n) (substitute_formula f2 s n)
-| _ (all f)      s n := all (substitute_formula f s (n+1))
+| _ (apprel f t) s n := apprel (subst_formula f s n) (subst_term t s n)
+| _ (f1 ⟹ f2)   s n := subst_formula f1 s n ⟹ subst_formula f2 s n
+| _ (∀∀ f)       s n := ∀∀ subst_formula f s (n+1)
 
-notation f `[`:95 s ` // `:95 n `]`:0 := _root_.fol.substitute_formula f s n
+notation f `[`:95 s ` // `:95 n `]`:0 := _root_.fol.subst_formula f s n
 
-@[simp] def substitute_formula_equal (t₁ t₂ s : term) (n : ℕ) :
+lemma subst_formula_equal (t₁ t₂ s : term) (n : ℕ) :
   (t₁ ≃ t₂)[s // n] = t₁[s // n] ≃ (t₂[s // n]) :=
-by refl
+by simp
 
--- ⟹⇔≃
+/- this lemma is in the other directions as similar lemma's, because only in this direction
+  simp* can do the `all` case, and I'm lazy. -/
+lemma lift_at_subst_formula_large' : ∀{l} (f : preformula l) (s : term) {n₁ n₂ m}, m ≤ n₁ →
+  (f [s // n₁]) ↑ n₂ # m = (f ↑ n₂ # m)[s // n₁+n₂]
+| _ false        s n₁ n₂ m h := by refl
+| _ (t1 ≃ t2)    s n₁ n₂ m h := by simp [*, lift_at_subst_term_large]
+| _ (rel R)      s n₁ n₂ m h := by refl
+| _ (apprel f t) s n₁ n₂ m h := by simp [*, lift_at_subst_term_large]
+| _ (f1 ⟹ f2)   s n₁ n₂ m h := by simp*
+| _ (∀∀ f)       s n₁ n₂ m h := by simp*
+
+lemma lift_subst_formula_large {l} (f : preformula l) (s : term) {n₁ n₂} :
+ (f ↑↑ n₂)[s // n₁+n₂] = (f [s // n₁]) ↑↑ n₂ :=
+(lift_at_subst_formula_large' f s n₁.zero_le).symm
+
+lemma subst_formula2 : ∀{l} (f : preformula l) (s₁ s₂ : term) (n₁ n₂),
+  f [s₁ // n₁] [s₂ // n₁ + n₂] = f [s₂ // n₁ + n₂ + 1] [s₁[s₂ // n₂] // n₁]
+| _ false        s₁ s₂ n₁ n₂ := by refl
+| _ (t1 ≃ t2)    s₁ s₂ n₁ n₂ := by simp [*, subst_term2]
+| _ (rel R)      s₁ s₂ n₁ n₂ := by refl
+| _ (apprel f t) s₁ s₂ n₁ n₂ := by simp [*, subst_term2]
+| _ (f1 ⟹ f2)   s₁ s₂ n₁ n₂ := by simp*
+| _ (∀∀ f)       s₁ s₂ n₁ n₂ := 
+  by simp*; rw [add_comm n₂ 1, ←add_assoc, subst_formula2 f s₁ s₂ (n₁ + 1) n₂]; simp
+
+lemma subst_formula2_zero {l} (f : preformula l) (s₁ s₂ : term) (n) :
+  f [s₁ // 0] [s₂ // n] = f [s₂ // n + 1] [s₁[s₂ // n] // 0] :=
+let h := subst_formula2 f s₁ s₂ 0 n in by simp at h; exact h
+
 /- Provability relation
 * to decide: should Γ be a list or a set (or finset)?
 * We use natural deduction as our deduction system, since that is most convenient to work with.
@@ -248,34 +395,15 @@ inductive prf : list formula → formula → Type
 | axm    : ∀{Γ A}, A ∈ Γ → prf Γ A
 | impI   : ∀{Γ A B}, prf (A::Γ) B → prf Γ (A ⟹ B)
 | impE   : ∀{Γ} (A) {B}, prf Γ (A ⟹ B) → prf Γ A → prf Γ B
-| falseE : ∀{Γ A}, prf (not A::Γ) false → prf Γ A
-| allI   : ∀{Γ A}, prf (map lift_formula1 Γ) A → prf Γ (all A)
-| allE'  : ∀{Γ} A t, prf Γ (all A) → prf Γ (A[t // 0])
+| falseE : ∀{Γ A}, prf (∼A::Γ) false → prf Γ A
+| allI   : ∀{Γ A}, prf (map lift_formula1 Γ) A → prf Γ (∀∀ A)
+| allE'  : ∀{Γ} A t, prf Γ (∀∀ A) → prf Γ (A[t // 0])
 | refl   : ∀Γ t, prf Γ (t ≃ t)
 | subst' : ∀{Γ} s t f, prf Γ (s ≃ t) → prf Γ (f[s // 0]) → prf Γ (f[t // 0])
 open prf
 infix ` ⊢ `:51 := _root_.fol.prf -- input: \|- or \vdash
 
-def weakening {Γ Δ} {f : formula} (H₁ : Γ ⊆ Δ) (H₂ : Γ ⊢ f) : Δ ⊢ f :=
-begin
-  induction H₂ generalizing Δ,
-  { apply axm, exact H₁ H₂_a, },
-  { apply impI, apply H₂_ih, simp [cons_subset_cons, H₁] },
-  { apply impE, apply H₂_ih_a, assumption, apply H₂_ih_a_1, assumption },
-  { apply falseE, apply H₂_ih, simp [cons_subset_cons, H₁] },
-  { apply allI, apply H₂_ih, sorry /-simp [cons_subset_cons, H₁]-/ },
-  { apply allE', apply H₂_ih, assumption },
-  { apply refl },
-  { apply subst', apply H₂_ih_a, assumption, apply H₂_ih_a_1, assumption },
-end
-
-def weakening_cons {Γ} {f₁ f₂ : formula} (H : Γ ⊢ f₂) : f₁::Γ ⊢ f₂ :=
-weakening (Γ.subset_cons f₁) H
-
-def weakening_cons2 {Γ} {f₁ f₂ f₃ : formula} (H : f₁::Γ ⊢ f₂) : f₁::f₃::Γ ⊢ f₂ :=
-weakening (cons_subset_cons _ (Γ.subset_cons _)) H
-
-def allE {Γ} (A : formula) (t) {B} (H₁ : prf Γ (all A)) (H₂ : A[t // 0] = B) : prf Γ B :=
+def allE {Γ} (A : formula) (t) {B} (H₁ : prf Γ (∀∀ A)) (H₂ : A[t // 0] = B) : prf Γ B :=
 by induction H₂; exact allE' A t H₁
 
 def subst {Γ} {s t} (f₁ : formula) {f₂} (H₁ : prf Γ (s ≃ t)) (H₂ : prf Γ (f₁[s // 0])) 
@@ -285,44 +413,75 @@ by induction H₃; exact subst' s t f₁ H₁ H₂
 def axm1 {Γ} {A : formula} : A::Γ ⊢ A := by apply axm; left; refl
 def axm2 {Γ} {A B : formula} : A::B::Γ ⊢ B := by apply axm; right; left; refl
 
+def weakening {Γ Δ} {f : formula} (H₁ : Γ ⊆ Δ) (H₂ : Γ ⊢ f) : Δ ⊢ f :=
+begin
+  induction H₂ generalizing Δ,
+  { apply axm, exact H₁ H₂_a, },
+  { apply impI, apply H₂_ih, simp [cons_subset_cons, H₁] },
+  { apply impE, apply H₂_ih_a, assumption, apply H₂_ih_a_1, assumption },
+  { apply falseE, apply H₂_ih, simp [cons_subset_cons, H₁] },
+  { apply allI, apply H₂_ih, apply map_subset _ H₁ },
+  { apply allE', apply H₂_ih, assumption },
+  { apply refl },
+  { apply subst', apply H₂_ih_a, assumption, apply H₂_ih_a_1, assumption },
+end
+
+def substitution {Γ} {f : formula} {t n} (H : Γ ⊢ f) : map (λx, x[t // n]) Γ ⊢ f[t // n] :=
+begin
+  induction H generalizing n,
+  { apply axm, apply mem_map_of_mem _ H_a, },
+  { apply impI, apply H_ih },
+  { apply impE, apply H_ih_a, apply H_ih_a_1 },
+  { apply falseE, apply H_ih },
+  { apply allI, rw list.map_map, have h := @H_ih (n+1), rw list.map_map at h, 
+    apply cast _ h, congr1; [skip, refl], apply map_congr, intros,
+    apply lift_subst_formula_large },
+  { apply allE _ _ H_ih, symmetry, apply subst_formula2_zero },
+  { apply refl },
+  { apply subst _ H_ih_a, { have h := @H_ih_a_1 n, rw [subst_formula2_zero] at h, exact h}, 
+    rw [subst_formula2_zero] },
+end
+
+def weakening1 {Γ} {f₁ f₂ : formula} (H : Γ ⊢ f₂) : f₁::Γ ⊢ f₂ :=
+weakening (Γ.subset_cons f₁) H
+
+def weakening2 {Γ} {f₁ f₂ f₃ : formula} (H : f₁::Γ ⊢ f₂) : f₁::f₃::Γ ⊢ f₂ :=
+weakening (cons_subset_cons _ (Γ.subset_cons _)) H
+
 def deduction {Γ} {A B : formula} (H : Γ ⊢ A ⟹ B) : A::Γ ⊢ B :=
-impE A (weakening_cons H) axm1
+impE A (weakening1 H) axm1
 
 def exfalso {Γ} {A : formula} (H : prf Γ false) : prf Γ A :=
-falseE (weakening_cons H)
+falseE (weakening1 H)
 
 def andI {Γ} {f₁ f₂ : formula} (H₁ : Γ ⊢ f₁) (H₂ : Γ ⊢ f₂) : Γ ⊢ f₁ ⊓ f₂ :=
 begin 
   apply impI, apply impE f₂,
-  { apply impE f₁, apply axm1, exact weakening_cons H₁ },
-  { exact weakening_cons H₂ }
+  { apply impE f₁, apply axm1, exact weakening1 H₁ },
+  { exact weakening1 H₂ }
 end
 
 def andE1 {Γ f₁} (f₂ : formula) (H : Γ ⊢ f₁ ⊓ f₂) : Γ ⊢ f₁ :=
 begin 
-  apply falseE, apply impE _ (weakening_cons H), apply impI, apply exfalso,
+  apply falseE, apply impE _ (weakening1 H), apply impI, apply exfalso,
   apply impE f₁; [apply axm2, apply axm1]
 end
 
 def andE2 {Γ} (f₁ : formula) {f₂} (H : Γ ⊢ f₁ ⊓ f₂) : Γ ⊢ f₂ :=
-begin 
-  apply falseE, apply impE _ (weakening_cons H), apply impI, apply axm2
-end
+begin apply falseE, apply impE _ (weakening1 H), apply impI, apply axm2 end
 
 def orI1 {Γ} {A B : formula} (H : Γ ⊢ A) : Γ ⊢ A ⊔ B :=
-begin
-  apply impI, apply exfalso, refine impE _ _ (weakening_cons H), apply axm1
-end
+begin apply impI, apply exfalso, refine impE _ _ (weakening1 H), apply axm1 end
 
 def orI2 {Γ} {A B : formula} (H : Γ ⊢ B) : Γ ⊢ A ⊔ B :=
-impI $ weakening_cons H
+impI $ weakening1 H
 
 def orE {Γ} {A B C : formula} (H₁ : Γ ⊢ A ⊔ B) (H₂ : A::Γ ⊢ C) (H₃ : B::Γ ⊢ C) : Γ ⊢ C :=
 begin
   apply falseE, apply impE C, { apply axm1 },
-  apply impE B, { apply impI, exact weakening_cons2 H₃ },
-  apply impE _ (weakening_cons H₁),
-  apply impI (impE _ axm2 (weakening_cons2 H₂))
+  apply impE B, { apply impI, exact weakening2 H₃ },
+  apply impE _ (weakening1 H₁),
+  apply impI (impE _ axm2 (weakening2 H₂))
 end
 
 def iffI {Γ} {f₁ f₂ : formula} (H₁ : f₁::Γ ⊢ f₂) (H₂ : f₂::Γ ⊢ f₁) : Γ ⊢ iff f₁ f₂ :=
@@ -334,27 +493,37 @@ deduction (andE1 _ H)
 def iffE2 {Γ} {f₁ f₂ : formula} (H : Γ ⊢ iff f₁ f₂) : f₂::Γ ⊢ f₁ :=
 deduction (andE2 _ H)
 
--- def ex (f : formula) : formula := not (all (not f))
+def exI {Γ f} (t : term) (H : Γ ⊢ f [t // 0]) : Γ ⊢ ∃∃ f :=
+begin
+  apply impI, 
+  apply impE (f[t // 0]) _ (weakening1 H),
+  apply allE' ∼f t axm1,
+end
+
+def exE {Γ f₁ f₂} (t : term) (H₁ : Γ ⊢ ∃∃ f₁) (H₂ : f₁::map lift_formula1 Γ ⊢ lift_formula1 f₂) :
+  Γ ⊢ f₂ :=
+begin
+  apply falseE, apply impE _ (weakening1 H₁), apply allI, apply impI, 
+  apply impE _ axm2, apply weakening2 H₂
+end
 
 def symm {Γ} {s t : term} (H : Γ ⊢ s ≃ t) : Γ ⊢ t ≃ s :=
 begin 
-  apply subst (&0 ≃ s ↑1) H; 
-    rw [substitute_formula_equal, substitute_term_lift_term, substitute_term_var_eq],
+  apply subst (&0 ≃ s ↑1) H; rw [subst_formula_equal, lift_term1_subst_term, subst_term_var0],
   apply refl
 end
 
 def trans {Γ} {t₁ t₂ t₃ : term} (H : Γ ⊢ t₁ ≃ t₂) (H' : Γ ⊢ t₂ ≃ t₃) : Γ ⊢ t₁ ≃ t₃ :=
 begin 
-  apply subst (t₁ ↑1 ≃ &0) H';
-    rw [substitute_formula_equal, substitute_term_lift_term, substitute_term_var_eq],
+  apply subst (t₁ ↑1 ≃ &0) H'; rw [subst_formula_equal, lift_term1_subst_term, subst_term_var0],
   exact H
 end
 
 def congr {Γ} {t₁ t₂ s : term} (H : Γ ⊢ t₁ ≃ t₂) : Γ ⊢ s[t₁ // 0] ≃ s[t₂ // 0] :=
 begin 
   apply subst (s[t₁ // 0] ↑1 ≃ s) H, 
-  { rw [substitute_formula_equal, substitute_term_lift_term], apply refl },
-  { rw [substitute_formula_equal, substitute_term_lift_term] }
+  { rw [subst_formula_equal, lift_term1_subst_term], apply refl },
+  { rw [subst_formula_equal, lift_term1_subst_term] }
 end
 
 end

--- a/language_term_n2.lean
+++ b/language_term_n2.lean
@@ -71,8 +71,8 @@ prefix `&`:max := _root_.fol.preterm.var
 
 notation t ` ↑ `:90 n ` # `:90 m:90 := _root_.fol.lift_term_at t n m -- input ↑ with \u or \upa
 
-@[reducible] def lift_term {l} (t : preterm l) (n : ℕ) : preterm l := t ↑ n # 0
-@[reducible] def lift_term1 {l} (t : preterm l) : preterm l := t ↑ 1 # 0
+@[reducible, simp] def lift_term {l} (t : preterm l) (n : ℕ) : preterm l := t ↑ n # 0
+@[reducible, simp] def lift_term1 {l} (t : preterm l) : preterm l := t ↑ 1 # 0
 
 infix ` ↑↑ `:100 := _root_.fol.lift_term -- input ↑ with \upa
 postfix ` ↑1`:100 := _root_.fol.lift_term1 -- input ↑ with \upa
@@ -103,7 +103,7 @@ lemma lift_term_at2_small : ∀ {l} (t : preterm l) (n n') {m m'}, m' ≤ m →
 | _ &k          n n' m m' H := 
   begin 
     by_cases h : m ≤ k,
-    { have h₁ : m' ≤ k, from le_trans H h,
+    { have h₁ : m' ≤ k := le_trans H h,
       have h₂ : m' ≤ k + n, from le_trans h₁ (k.le_add_right n),
       simp [*, -add_assoc, -add_comm], simp },
     { have h₁ : ¬m + n' ≤ k + n', from λ h', h (le_of_add_le_add_right h'),
@@ -272,7 +272,7 @@ open preformula
 def not (f : formula) : formula := imp f falsum
 def and (f₁ f₂ : formula) : formula := not (imp f₁ (not f₂))
 def or (f₁ f₂ : formula) : formula := imp (not f₁) f₂
-def iff (f₁ f₂ : formula) : formula := and (imp f₁ f₂) (imp f₂ f₁)
+def biimp (f₁ f₂ : formula) : formula := and (imp f₁ f₂) (imp f₂ f₁)
 def ex (f : formula) : formula := not (all (not f))
 
 notation `⊥` := _root_.fol.preformula.falsum -- input: \bot
@@ -295,8 +295,8 @@ prefix `∃∃`:110 := _root_.fol.ex
 
 notation f ` ↑ `:90 n ` # `:90 m:90 := _root_.fol.lift_formula_at f n m -- input ↑ with \upa
 
-@[reducible] def lift_formula {l} (f : preformula l) (n : ℕ) : preformula l := f ↑ n # 0
-@[reducible] def lift_formula1 {l} (f : preformula l) : preformula l := f ↑ 1 # 0
+@[reducible, simp] def lift_formula {l} (f : preformula l) (n : ℕ) : preformula l := f ↑ n # 0
+@[reducible, simp] def lift_formula1 {l} (f : preformula l) : preformula l := f ↑ 1 # 0
 
 infix ` ↑↑ `:100 := _root_.fol.lift_formula -- input ↑ with \upa
 postfix ` ↑1`:100 := _root_.fol.lift_formula1 -- input ↑ with \upa
@@ -347,7 +347,7 @@ lemma lift_formula_at2_eq {l} (f : preformula l) (n n' m : ℕ) :
   (f ↑ n # m) ↑ n' # (m+n) = f ↑ (n+n') # m :=
 lift_formula_at2_medium f n n' (m.le_add_right n) (le_refl _)
 
-lemma lift_formula_at2_large {l} (f : preformula l) (n n') {m m'} (H : m' ≥ m + n) : 
+lemma lift_formula_at2_large {l} (f : preformula l) (n n') {m m'} (H : m + n ≤ m') : 
   (f ↑ n # m) ↑ n' # m' = (f ↑ n' # (m'-n)) ↑ n # m :=
 have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
 have H₂ : m ≤ m' - n, from nat.le_sub_right_of_add_le H,
@@ -494,13 +494,13 @@ begin
   apply impI (impE _ axm2 (weakening2 H₂))
 end
 
-def iffI {Γ} {f₁ f₂ : formula} (H₁ : f₁::Γ ⊢ f₂) (H₂ : f₂::Γ ⊢ f₁) : Γ ⊢ iff f₁ f₂ :=
+def biimpI {Γ} {f₁ f₂ : formula} (H₁ : f₁::Γ ⊢ f₂) (H₂ : f₂::Γ ⊢ f₁) : Γ ⊢ biimp f₁ f₂ :=
 by apply andI; apply impI; assumption
 
-def iffE1 {Γ} {f₁ f₂ : formula} (H : Γ ⊢ iff f₁ f₂) : f₁::Γ ⊢ f₂ :=
+def biimpE1 {Γ} {f₁ f₂ : formula} (H : Γ ⊢ biimp f₁ f₂) : f₁::Γ ⊢ f₂ :=
 deduction (andE1 _ H)
 
-def iffE2 {Γ} {f₁ f₂ : formula} (H : Γ ⊢ iff f₁ f₂) : f₂::Γ ⊢ f₁ :=
+def biimpE2 {Γ} {f₁ f₂ : formula} (H : Γ ⊢ biimp f₁ f₂) : f₂::Γ ⊢ f₁ :=
 deduction (andE2 _ H)
 
 def exI {Γ f} (t : term) (H : Γ ⊢ f [t // 0]) : Γ ⊢ ∃∃ f :=
@@ -536,33 +536,53 @@ begin
   { rw [subst_formula_equal, lift_term1_subst_term] }
 end
 
+/- sentences -/
+-- def term_variables_below : Π{l}, preterm l → ℕ → Prop
+-- | _ &k          n := if k < n then true else false
+-- | _ (func f)    n := true
+-- | _ (app t1 t2) n := term_variables_below t1 n ∧ term_variables_below t2 n
+
+-- def formula_variables_below : Π{l}, preformula l → ℕ → Prop
+-- | _ falsum       n := true
+-- | _ (t1 ≃ t2)    n := term_variables_below t1 n ∧ term_variables_below t2 n 
+-- | _ (rel R)      n := true
+-- | _ (apprel f t) n := formula_variables_below f n ∧ term_variables_below t n
+-- | _ (f1 ⟹ f2)   n := formula_variables_below f1 n ∧ formula_variables_below f2 n
+-- | _ (∀∀ f)       n := formula_variables_below f (n+1)
+
+-- def is_sentence {l} (t : preformula l) := formula_variables_below t 0
+-- def sentence := { t : formula // is_sentence t }
+
+
+/- model theory -/
+/-- The type α → (α → ... (α → β)...) with n α's. We require that α and β live in the same universe, otherwise we have to use ulift. -/
 def arity (α β : Type u) : ℕ → Type u
 | 0     := β
 | (n+1) := α → arity n
 
-def arity_map2 {α β : Type u} (q : (α → β) → β)(f : β → β → β) : 
+def for_all {α : Type u} (P : α → Prop) : Prop := ∀x, P x
+
+@[simp] def arity_map2 {α β : Type u} (q : (α → β) → β) (f : β → β → β) : 
   ∀{n}, arity α β n → arity α β n → β
 | 0     x y := f x y
 | (n+1) x y := q (λz, arity_map2 (x z) (y z))
 
+@[simp] lemma arity_map2_refl {α : Type} {f : Prop → Prop → Prop} (r : ΠA, f A A) : 
+  ∀{n} (x : arity α Prop n), arity_map2 for_all f x x
+| 0     x := r x
+| (n+1) x := λy, arity_map2_refl (x y)
+
 def arity_imp {α : Type} {n : ℕ} (f₁ f₂ : arity α Prop n) : Prop := 
-arity_map2 (λP, ∀x, P x) (λP Q, P → Q) f₁ f₂
+arity_map2 for_all (λP Q, P → Q) f₁ f₂
 
-def term_variables_below : Π{l}, preterm l → ℕ → Prop
-| _ &k          n := if k < n then true else false
-| _ (func f)    n := true
-| _ (app t1 t2) n := term_variables_below t1 n ∧ term_variables_below t2 n
+def arity_iff {α : Type} {n : ℕ} (f₁ f₂ : arity α Prop n) : Prop := 
+arity_map2 for_all iff f₁ f₂
 
-def formula_variables_below : Π{l}, preformula l → ℕ → Prop
-| _ falsum       n := true
-| _ (t1 ≃ t2)    n := term_variables_below t1 n ∧ term_variables_below t2 n 
-| _ (rel R)      n := true
-| _ (apprel f t) n := formula_variables_below f n ∧ term_variables_below t n
-| _ (f1 ⟹ f2)   n := formula_variables_below f1 n ∧ formula_variables_below f2 n
-| _ (∀∀ f)       n := formula_variables_below f (n+1)
+lemma arity_iff_refl {α : Type} {n : ℕ} (f : arity α Prop n) : arity_iff f f := 
+arity_map2_refl iff.refl f
 
-def is_sentence {l} (t : preformula l) := formula_variables_below t 0
-def sentence := { t : formula // is_sentence t }
+lemma arity_iff_rfl {α : Type} {n : ℕ} {f : arity α Prop n} : arity_iff f f := 
+arity_iff_refl f
 
 structure Structure :=
 (carrier : Type) 
@@ -572,29 +592,78 @@ structure Structure :=
 instance : has_coe_to_sort (@_root_.fol.Structure L) :=
 ⟨Type, Structure.carrier⟩
 
-/- realize of terms -/
-def realize_term {S : Structure} (v : ℕ → S) : Π{l}, preterm l → arity S S l
+/- realizers of variables are just maps ℕ → S. We need some operations on them -/
+def subst_realize {S : Type u} (v : ℕ → S) (x : S) (m n : ℕ) : S :=
+if n < m then v n else if m < n then v (n - 1) else x
+
+notation v `[`:95 x ` // `:95 m `]`:0 := _root_.fol.subst_realize v x m
+
+@[simp] lemma subst_realize_lt {S : Type u} (v : ℕ → S) (x : S) {m n : ℕ} (H : n < m) : 
+  v[x // m] n = v n :=
+by simp [H, subst_realize]
+
+@[simp] lemma subst_realize_gt {S : Type u} (v : ℕ → S) (x : S) {m n : ℕ} (H : m < n) : 
+  v[x // m] n = v (n-1) :=
+have h : ¬(n < m), from lt_asymm H,
+by simp [*, subst_realize]
+
+@[simp] lemma subst_realize_var_eq {S : Type u} (v : ℕ → S) (x : S) (n : ℕ) : v[x // n] n = x :=
+by simp [subst_realize, lt_irrefl]
+
+lemma subst_realize_congr {S : Type u} {v v' : ℕ → S} (hv : ∀n, v n = v' n) (x : S) (m n : ℕ) : 
+ v [x // m] n = v' [x // m] n :=
+by apply lt_by_cases n m; intro h; simp*
+
+lemma subst_realize2 {S : Type u} (v : ℕ → S) (x x' : S) (m m' n : ℕ) :
+  v [x // m] [x' // m + m' + 1] n = v [x' // m + m'] [x // m] n :=
+begin
+  sorry
+end
+
+/- realization of terms -/
+@[simp] def realize_term {S : Structure} (v : ℕ → S) : Π{l}, preterm l → arity S S l
 | _ &k          := v k
 | _ (func f)    := S.fun_map f
 | _ (app t1 t2) := realize_term t1 $ realize_term t2
 
-open ulift
-def realize_succ {S : Type u} (x : S) (v : ℕ → S) : ℕ → S
-| 0     := x
-| (n+1) := v n
+lemma realize_term_congr {S : Structure} {v v' : ℕ → S} (h : ∀n, v n = v' n) : 
+  Π{l} (t : preterm l), realize_term v t = realize_term v' t
+| _ &k          := h k
+| _ (func f)    := by refl
+| _ (app t1 t2) := by dsimp; rw [realize_term_congr t1, realize_term_congr t2]
 
-/- realize of terms -/
+lemma subst_realize_term {S : Structure} (v : ℕ → S) (x : S) (m : ℕ) : Π{l} (t : preterm l),
+  realize_term (v [x // m]) (t ↑ 1 # m) = realize_term v t
+| _ &k          := 
+  begin 
+    by_cases h : m ≤ k, 
+    { have : m < k + 1, from lt_succ_of_le h, simp* },
+    { have : k < m, from lt_of_not_ge h, simp* }
+  end
+| _ (func f)    := by refl
+| _ (app t1 t2) := by simp*
+
+/- realization of formulas -/
 @[simp] def realize_formula {S : Structure} : Π{l}, (ℕ → S) → preformula l → arity S Prop l
 | _ v falsum       := false
 | _ v (t1 ≃ t2)    := realize_term v t1 = realize_term v t2
 | _ v (rel R)      := S.rel_map R
 | _ v (apprel f t) := realize_formula v f $ realize_term v t
 | _ v (f1 ⟹ f2)   := realize_formula v f1 → realize_formula v f2
-| _ v (∀∀ f)       := ∀(x : S), realize_formula (realize_succ x v) f
+| _ v (∀∀ f)       := ∀(x : S), realize_formula (v [x // 0]) f
 
-def realize_formula_succ {S : Structure} (x : S) : Π{l} (v : ℕ → S) (f : preformula l),
-  arity_imp (realize_formula v f) (realize_formula (realize_succ x v) (f ↑1)) :=
+lemma realize_formula_congr {S : Structure} : Π{l} {v v' : ℕ → S} (h : ∀n, v n = v' n) 
+  (f : preformula l), arity_iff (realize_formula v f) (realize_formula v' f) :=
 sorry
+
+lemma subst_realize_formula {S : Structure} : Π{l} (v : ℕ → S) (x : S) (m : ℕ) (f : preformula l),
+  arity_iff (realize_formula (v [x // m]) (f ↑ 1 # m)) (realize_formula v f)
+| _ v x m falsum       := iff.rfl
+| _ v x m (t1 ≃ t2)    := by simp [arity_iff, subst_realize_term]
+| _ v x m (rel R)      := arity_iff_rfl
+| _ v x m (apprel f t) := by simp [subst_realize_term]; exact subst_realize_formula v x m f _
+| _ v x m (f1 ⟹ f2)   := by apply imp_congr; exact @subst_realize_formula 0 v x m _
+| _ v x m (∀∀ f)       := by apply forall_congr; intro x'; sorry
 
 def provable (T : set formula) (f : formula) :=
 ∃(Γ : list formula), Γ.to_set ⊆ T ∧ nonempty (Γ ⊢ f)
@@ -616,18 +685,16 @@ def all_satisfied (T : set formula) (S : set formula) :=
 infix ` ⊢ `:51 := _root_.fol.provable -- input: \|- or \vdash
 infix ` ⊢ `:51 := _root_.fol.all_provable -- input: \|- or \vdash
 
-def soundness' (Γ : list formula) (A : formula) (H : Γ ⊢ A) : Γ.to_set ⊨ A :=
+lemma soundness' (Γ : list formula) (A : formula) (H : Γ ⊢ A) : Γ.to_set ⊨ A :=
 begin
   intro S, induction H; intros v h,
   { apply h, simp [H_a, list.to_set] },
-  { intro ha, apply H_ih, intros f hf, induction hf, { subst hf, assumption },
-    apply h f hf },
+  { intro ha, apply H_ih, intros f hf, induction hf, { subst hf, assumption }, apply h f hf },
   { exact H_ih_a v h (H_ih_a_1 v h) },
   { apply classical.by_contradiction, intro ha, 
-    apply H_ih v, intros f hf, induction hf, { cases hf, exact ha }, 
-    apply h f hf },
-  { intro x, apply H_ih, intros f hf, cases exists_of_mem_map hf with f' hf', 
-    induction hf', induction hf'_right, exact realize_formula_succ x v f' (h f' hf'_left) },
+    apply H_ih v, intros f hf, induction hf, { cases hf, exact ha }, apply h f hf },
+  { intro x, apply H_ih, intros f hf, cases exists_of_mem_map hf with f' hf', induction hf', 
+    induction hf'_right, exact (subst_realize_formula v x 0 f').2 (h f' hf'_left) },
   { sorry },
   { dsimp, refl },
   { sorry },

--- a/language_term_n2.lean
+++ b/language_term_n2.lean
@@ -4,10 +4,11 @@ meta def congr1 : tactic unit := congr_core
 end interactive
 end tactic
 
+namespace fol
 structure Language := 
-(relations : Π n : nat, Type) (functions : Π  n : nat, Type)
+(relations : ℕ → Type) (functions : ℕ → Type) (equal : relations 2) (false : relations 0)
 section
-parameter L : Language
+parameter {L : Language}
 
 /- preterm n is a partially applied term. if applied to n terms, it becomes a term -/
 inductive preterm : ℕ → Type 
@@ -15,41 +16,46 @@ inductive preterm : ℕ → Type
 | func : ∀ {n : nat}, L.functions n → preterm n
 | apply : ∀ {n : nat}, preterm (n + 1) → preterm 0 → preterm n
 open preterm
-def term := preterm 0
+@[reducible] def term := preterm 0
 
-/- lift_term _ t n m raises variables in t which are at least m by n -/
-@[simp] def lift_term : ∀ {l}, preterm l → ℕ → ℕ → preterm l
-| _ (var L k)     n m := if m ≤ k then var (k+n) else var k
+local prefix `&`:max := var
+
+/- lift_term_at _ t n m raises variables in t which are at least m by n -/
+@[simp] def lift_term_at : ∀ {l}, preterm l → ℕ → ℕ → preterm l
+| _ (var k)       n m := if m ≤ k then var (k+n) else var k
 | _ (func f)      n m := func f
-| _ (apply t1 t2) n m := apply (lift_term t1 n m) (lift_term t2 n m)
+| _ (apply t1 t2) n m := apply (lift_term_at t1 n m) (lift_term_at t2 n m)
 
-local notation [parsing_only] t ` ↑ `:55 n ` # `:55 m:55 := lift_term t n m
+local notation t ` ↑ `:55 n ` # `:55 m:55 := lift_term_at t n m
 
-lemma lift_term_inj : ∀ {l} {t t' : preterm l} {n m : ℕ}, t ↑ n # m = t' ↑ n # m → t = t'
-| _ (var L k) (var .(L) k')   n m h := 
+def lift_term (t : term) (n : ℕ) : term := t ↑ n # 0
+def lift_term1 (t : term) : term := t ↑ 1 # 0
+
+lemma lift_term_at_inj : ∀ {l} {t t' : preterm l} {n m : ℕ}, t ↑ n # m = t' ↑ n # m → t = t'
+| _ (var k) (var k')          n m h := 
   by by_cases h₁ : m ≤ k; by_cases h₂ : m ≤ k'; simp [h₁, h₂] at h; congr; 
        [exact add_right_cancel h, skip, skip, assumption]; exfalso; 
        try {apply h₁}; try {apply h₂}; subst h; 
        apply le_trans (by assumption) (nat.le_add_right _ _)
-| _ (var L k) (func f')       n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
-| _ (var L k) (apply t1' t2') n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
-| _ (func f) (var .(L) k')    n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
+| _ (var k) (func f')         n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
+| _ (var k) (apply t1' t2')   n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
+| _ (func f) (var k')         n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
 | _ (func f) (func f')        n m h := h
 | _ (func f) (apply t1' t2')  n m h := by cases h
-| _ (apply t1 t2) (var _ k')  n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
+| _ (apply t1 t2) (var k')    n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
 | _ (apply t1 t2) (func f')   n m h := by cases h
 | _ (apply t1 t2) (apply t1' t2') n m h := 
-  begin injection h, congr; apply lift_term_inj; assumption end
+  begin injection h, congr; apply lift_term_at_inj; assumption end
 
-@[simp] lemma lift_term_zero : ∀ {l} (t : preterm l) (m : ℕ), t ↑ 0 # m = t
-| _ (var L k)     m := by simp
+@[simp] lemma lift_term_at_zero : ∀ {l} (t : preterm l) (m : ℕ), t ↑ 0 # m = t
+| _ (var k)     m := by simp
 | _ (func f)      m := by refl
-| _ (apply t1 t2) m := by dsimp; congr; apply lift_term_zero
+| _ (apply t1 t2) m := by dsimp; congr; apply lift_term_at_zero
 
 /- the following lemmas simplify iterated lifts, depending on the size of m' -/
-lemma lift_term2_small : ∀ {l} (t : preterm l) (n n') {m m'}, m' ≤ m → 
+lemma lift_term_at2_small : ∀ {l} (t : preterm l) (n n') {m m'}, m' ≤ m → 
   (t ↑ n # m) ↑ n' # m' = (t ↑ n' # m') ↑ n # (m + n')
-| _ (var L k)     n n' m m' H := 
+| _ (var k)       n n' m m' H := 
   begin 
     by_cases h : m ≤ k,
     { have h₁ : m' ≤ k, from le_trans H h,
@@ -62,11 +68,11 @@ lemma lift_term2_small : ∀ {l} (t : preterm l) (n n') {m m'}, m' ≤ m →
   end
 | _ (func f)      n n' m m' H := by refl
 | _ (apply t1 t2) n n' m m' H := 
-  begin dsimp; congr1; apply lift_term2_small; assumption end
+  begin dsimp; congr1; apply lift_term_at2_small; assumption end
 
-lemma lift_term2_medium : ∀ {l} (t : preterm l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
+lemma lift_term_at2_medium : ∀ {l} (t : preterm l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
   (t ↑ n # m) ↑ n' # m' = t ↑ (n+n') # m
-| _ (var L k)     n n' m m' H₁ H₂ := 
+| _ (var k)       n n' m m' H₁ H₂ := 
   begin 
     by_cases h : m ≤ k,
     { have h₁ : m' ≤ k + n, from le_trans H₂ (add_le_add_right h n),
@@ -77,28 +83,36 @@ lemma lift_term2_medium : ∀ {l} (t : preterm l) (n n') {m m'}, m ≤ m' → m'
   end
 | _ (func f)      n n' m m' H₁ H₂ := by refl
 | _ (apply t1 t2) n n' m m' H₁ H₂ := 
-  begin dsimp; congr1; apply lift_term2_medium; assumption end
+  begin dsimp; congr1; apply lift_term_at2_medium; assumption end
 
-lemma lift_term2_eq {l} (t : preterm l) (n n' m : ℕ) : 
+lemma lift_term_at2_eq {l} (t : preterm l) (n n' m : ℕ) : 
   (t ↑ n # m) ↑ n' # (m+n) = t ↑ (n+n') # m :=
-lift_term2_medium t n n' (m.le_add_right n) (le_refl _)
+lift_term_at2_medium t n n' (m.le_add_right n) (le_refl _)
 
-lemma lift_term2_large {l} (t : preterm l) (n n') {m m'} (H : m' ≥ m + n) : 
+lemma lift_term_at2_large {l} (t : preterm l) (n n') {m m'} (H : m' ≥ m + n) : 
   (t ↑ n # m) ↑ n' # m' = (t ↑ n' # m'-n) ↑ n # m :=
 have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
 have H₂ : m ≤ m' - n, by rw [←nat.add_sub_cancel m n]; apply nat.sub_le_sub_right; exact H,
-begin rw lift_term2_small t n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
+begin rw fol.lift_term_at2_small t n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
 
 /- substitute_term t s n substitutes s for (var n) and reduces the level of all variables above n by 1 -/
 @[simp] def substitute_term : ∀ {l}, preterm l → term → ℕ → preterm l
-| _ (var L k)     s n := if k < n then var k else if k > n then var (k-1) else s
+| _ (var k)     s n := if k < n then var k else if n < k then var (k-1) else s
 | _ (func f)      s n := func f
 | _ (apply t1 t2) s n := apply (substitute_term t1 s n) (substitute_term t2 s n)
 
+@[simp] def substitute_term_var_eq (t : term) (n : ℕ) : substitute_term &n t n = t :=
+by simp [lt_irrefl]
+
+lemma substitute_term_lift_term' : ∀{l} (t : preterm l) (s : term), 
+  substitute_term (lift_term_at t 1 0) s 0 = t :=
+sorry
+
+@[simp] lemma substitute_term_lift_term (t s : term) : substitute_term (lift_term1 t) s 0 = t :=
+substitute_term_lift_term' t s
+
 /- preformula n is a partially applied formula. if applied to n terms, it becomes a formula -/
 inductive preformula : ℕ → Type 
-| false : preformula 0
-| equal : term → term → preformula 0
 | rel : ∀ {n : nat}, L.relations n → preformula n
 | apprel : ∀ {n : nat}, preformula (n + 1) → term → preformula n
 | imp : preformula 0 → preformula 0 → preformula 0
@@ -106,65 +120,117 @@ inductive preformula : ℕ → Type
 open preformula
 def formula := preformula 0
 
-@[simp] def lift_formula : ∀ {l}, preformula l → ℕ → ℕ → preformula l
-| _ (false L)     n m := false
-| _ (equal t1 t2) n m := equal (lift_term t1 n m) (lift_term t2 n m)
-| _ (rel R)       n m := rel R
-| _ (apprel f t)  n m := apprel (lift_formula f n m) (lift_term t n m)
-| _ (imp f1 f2)   n m := imp (lift_formula f1 n m) (lift_formula f2 n m)
-| _ (all f)       n m := all (lift_formula f n (m+1))
+def equal (t₁ t₂ : term) : formula := apprel (apprel (rel L.equal) t₁) t₂
+def false : formula := rel L.false
+def not (f : formula) : formula := imp f false
+def or (f₁ f₂ : formula) : formula := imp (not f₁) f₂
+def and (f₁ f₂ : formula) : formula := not (imp f₁ (not f₂))
+def iff (f₁ f₂ : formula) : formula := and (imp f₁ f₂) (imp f₂ f₁)
+def ex (f : formula) : formula := not (all (not f))
 
-local notation [parsing_only] f ` ↑ `:55 n ` # `:55 m:55 := lift_formula f n m
+local infix ` ⟾ `:70 := imp
+local infix ` ⇔ `:75 := iff
+local infix ` ≍ `:80 := equal
 
-@[simp] lemma lift_formula_zero : ∀ {l} (f : preformula l) (m : ℕ), f ↑ 0 # m = f
-| _ (false L)     m := by refl
-| _ (equal t1 t2) m := by simp
-| _ (rel R)       m := by refl
-| _ (apprel f t)  m := by simp; apply lift_formula_zero
-| _ (imp f1 f2)   m := by dsimp; congr1; apply lift_formula_zero
-| _ (all f)       m := by simp; apply lift_formula_zero
+@[simp] def lift_formula_at : ∀ {l}, preformula l → ℕ → ℕ → preformula l
+| _ (rel R)      n m := rel R
+| _ (apprel f t) n m := apprel (lift_formula_at f n m) (lift_term_at t n m)
+| _ (imp f1 f2)  n m := imp (lift_formula_at f1 n m) (lift_formula_at f2 n m)
+| _ (all f)      n m := all (lift_formula_at f n (m+1))
+
+local notation f ` ↑ `:55 n ` # `:55 m:55 := lift_formula_at f n m
+
+def lift_formula (f : formula) (n : ℕ) : formula := f ↑ n # 0
+def lift_formula1 (f : formula) : formula := f ↑ 1 # 0
+
+lemma lift_formula_at_inj {l} {f f' : preformula l} {n m : ℕ} (H : f ↑ n # m = f' ↑ n # m) : f = f' :=
+begin
+  induction f generalizing m; cases f'; injection H,
+  simp [f_ih h_1, fol.lift_term_at_inj h_2],
+  simp [f_ih_a h_1, f_ih_a_1 h_2],
+  simp [f_ih h_1]
+end
+
+@[simp] lemma lift_formula_at_zero : ∀ {l} (f : preformula l) (m : ℕ), f ↑ 0 # m = f
+| _ (rel R)      m := by refl
+| _ (apprel f t) m := by simp; apply lift_formula_at_zero
+| _ (imp f1 f2)  m := by dsimp; congr1; apply lift_formula_at_zero
+| _ (all f)      m := by simp; apply lift_formula_at_zero
 
 /- the following lemmas simplify iterated lifts, depending on the size of m' -/
-lemma lift_formula2_small : ∀ {l} (f : preformula l) (n n') {m m'}, m' ≤ m → 
+lemma lift_formula_at2_small : ∀ {l} (f : preformula l) (n n') {m m'}, m' ≤ m → 
   (f ↑ n # m) ↑ n' # m' = (f ↑ n' # m') ↑ n # (m + n')
-| _ (false L)     n n' m m' H := by refl
-| _ (equal t1 t2) n n' m m' H := by simp [lift_term2_small, H]
-| _ (rel R)       n n' m m' H := by refl
-| _ (apprel f t)  n n' m m' H := 
-  by simp [lift_term2_small, H, -add_comm]; apply lift_formula2_small; assumption
-| _ (imp f1 f2)   n n' m m' H := by dsimp; congr1; apply lift_formula2_small; assumption
-| _ (all f)       n n' m m' H :=
-  by simp [lift_term2_small, H, lift_formula2_small f n n' (add_le_add_right H 1)]
+| _ (rel R)      n n' m m' H := by refl
+| _ (apprel f t) n n' m m' H := 
+  by simp [lift_term_at2_small, H, -add_comm]; apply lift_formula_at2_small; assumption
+| _ (imp f1 f2)  n n' m m' H := by dsimp; congr1; apply lift_formula_at2_small; assumption
+| _ (all f)      n n' m m' H :=
+  by simp [lift_term_at2_small, H, lift_formula_at2_small f n n' (add_le_add_right H 1)]
 
-lemma lift_formula2_medium : ∀ {l} (f : preformula l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
+lemma lift_formula_at2_medium : ∀ {l} (f : preformula l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
   (f ↑ n # m) ↑ n' # m' = f ↑ (n+n') # m
-| _ (false L)     n n' m m' H₁ H₂ := by refl
-| _ (equal t1 t2) n n' m m' H₁ H₂ := by simp [lift_term2_medium, H₁, H₂]
-| _ (rel R)       n n' m m' H₁ H₂ := by refl
-| _ (apprel f t)  n n' m m' H₁ H₂ :=
-  by simp [lift_term2_medium, H₁, H₂, -add_comm]; apply lift_formula2_medium; assumption
-| _ (imp f1 f2)   n n' m m' H₁ H₂ := by dsimp; congr1; apply lift_formula2_medium; assumption
-| _ (all f)       n n' m m' H₁ H₂ :=
+| _ (rel R)      n n' m m' H₁ H₂ := by refl
+| _ (apprel f t) n n' m m' H₁ H₂ :=
+  by simp [lift_term_at2_medium, H₁, H₂, -add_comm]; apply lift_formula_at2_medium; assumption
+| _ (imp f1 f2)  n n' m m' H₁ H₂ := by dsimp; congr1; apply lift_formula_at2_medium; assumption
+| _ (all f)      n n' m m' H₁ H₂ :=
   have m' + 1 ≤ (m + 1) + n, from le_trans (add_le_add_right H₂ 1) (by simp),
-  by simp [lift_term2_medium, H₁, H₂, lift_formula2_medium f n n' (add_le_add_right H₁ 1) this]
+  by simp [lift_term_at2_medium, H₁, H₂, lift_formula_at2_medium f n n' (add_le_add_right H₁ 1) this]
 
-lemma lift_formula2_eq {l} (f : preformula l) (n n' m : ℕ) : 
+lemma lift_formula_at2_eq {l} (f : preformula l) (n n' m : ℕ) : 
   (f ↑ n # m) ↑ n' # (m+n) = f ↑ (n+n') # m :=
-lift_formula2_medium f n n' (m.le_add_right n) (le_refl _)
+lift_formula_at2_medium f n n' (m.le_add_right n) (le_refl _)
 
-lemma lift_formula2_large {l} (f : preformula l) (n n') {m m'} (H : m' ≥ m + n) : 
+lemma lift_formula_at2_large {l} (f : preformula l) (n n') {m m'} (H : m' ≥ m + n) : 
   (f ↑ n # m) ↑ n' # m' = (f ↑ n' # m'-n) ↑ n # m :=
 have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
 have H₂ : m ≤ m' - n, by rw [←nat.add_sub_cancel m n]; apply nat.sub_le_sub_right; exact H,
-begin rw lift_formula2_small f n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
+begin rw fol.lift_formula_at2_small f n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
 
 @[simp] def substitute_formula : ∀ {l}, preformula l → term → ℕ → preformula l
-| _ (false L)     s n := false
-| _ (equal t1 t2) s n := equal (substitute_term t1 s n) (substitute_term t2 s n)
-| _ (rel R)       s n := rel R
-| _ (apprel f t)  s n := apprel (substitute_formula f s n) (substitute_term t s n)
-| _ (imp f1 f2)   s n := imp (substitute_formula f1 s n) (substitute_formula f2 s n)
-| _ (all f)       s n := all (substitute_formula f s (n+1))
+| _ (rel R)      s n := rel R
+| _ (apprel f t) s n := apprel (substitute_formula f s n) (substitute_term t s n)
+| _ (imp f1 f2)  s n := imp (substitute_formula f1 s n) (substitute_formula f2 s n)
+| _ (all f)      s n := all (substitute_formula f s (n+1))
 
+@[simp] def substitute_formula0 (f : formula) (t : term) := substitute_formula f t 0
+
+@[simp] def substitute_formula_equal (t₁ t₂ s : term) (n : ℕ) :
+  substitute_formula (t₁ ≍ t₂) s n = substitute_term t₁ s n ≍ substitute_term t₂ s n :=
+by refl
+
+-- ⟾⇔≍
+
+inductive prf : list formula → formula → Type
+| axm    : ∀{Γ A}, A ∈ Γ → prf Γ A
+| impI   : ∀{Γ A B}, prf (A::Γ) B → prf Γ (A ⟾ B)
+| impE   : ∀{Γ A B}, prf Γ (A ⟾ B) → prf Γ A → prf Γ B
+| falseE : ∀{Γ A}, prf (not A::Γ) false → prf Γ A
+| allI   : ∀{Γ A}, prf (list.map lift_formula1 Γ) A → prf Γ (all A)
+| allE   : ∀{Γ} A t, prf Γ (all A) → prf Γ (substitute_formula0 A t)
+| refl   : ∀Γ t, prf Γ (t ≍ t)
+| subst : ∀{Γ} s t f, prf Γ (s ≍ t) → prf Γ (substitute_formula f s 0) → 
+  prf Γ (substitute_formula f t 0)
+open prf
+local infix ` ⊢ `:51 := prf
+
+def symm {Γ s t} (H : Γ ⊢ s ≍ t) : Γ ⊢ t ≍ s :=
+begin 
+  have H₁ := subst s t (equal (var 0) (lift_term1 s)) H, -- why does notation not work here?
+  rw [substitute_formula_equal, substitute_formula_equal, substitute_term_lift_term, substitute_term_lift_term, substitute_term_var_eq, substitute_term_var_eq] at H₁,
+  exact H₁ (refl Γ s)
+end
+
+def trans {Γ t₁ t₂ t₃} (H : Γ ⊢ t₁ ≍ t₂) (H' : Γ ⊢ t₂ ≍ t₃) : Γ ⊢ t₁ ≍ t₃ :=
+begin 
+  have H₁ := prf.subst t₂ t₃ (equal (lift_term1 t₁) (var 0)) H', 
+  rw [substitute_formula_equal, substitute_formula_equal, substitute_term_lift_term, substitute_term_lift_term, substitute_term_var_eq, substitute_term_var_eq] at H₁,
+  exact H₁ H
+end
 
 end
+end fol
+open fol fol.preterm
+variable {L : Language}
+#check substitute_formula0 (@equal L (var 0) (var 0)) (var 7)
+#reduce substitute_formula0 (@equal L (var 0) (var 0)) (var 7)

--- a/language_term_n2.lean
+++ b/language_term_n2.lean
@@ -1,16 +1,30 @@
+/- A development of first-order logic in Lean.
+
+* The object theory uses classical logic
+* We use de Bruijn variables.
+* We use a deep embedding of the logic, i.e. the type of terms and formulas is inductively defined.
+* There is no well-formedness predicate; all elements of type "term" are well-formed.
+-/
+
+-- depend on mathlib
+--import data.list.basic
+
 namespace tactic
 namespace interactive
 meta def congr1 : tactic unit := congr_core
 end interactive
 end tactic
 
+open list
 namespace fol
 structure Language := 
-(relations : ℕ → Type) (functions : ℕ → Type) (equal : relations 2) (false : relations 0)
+(relations : ℕ → Type) (functions : ℕ → Type)
 section
 parameter {L : Language}
 
-/- preterm n is a partially applied term. if applied to n terms, it becomes a term -/
+/- preterm n is a partially applied term. if applied to n terms, it becomes a term.
+* Every element of preterm 0 is well typed. 
+* We use this encoding to avoid mutual or nested inductive types, since those are not too convenient to work with in Lean. -/
 inductive preterm : ℕ → Type 
 | var : ℕ → preterm 0
 | func : ∀ {n : nat}, L.functions n → preterm n
@@ -18,44 +32,46 @@ inductive preterm : ℕ → Type
 open preterm
 @[reducible] def term := preterm 0
 
-local prefix `&`:max := var
+prefix `&`:max := _root_.fol.preterm.var
 
 /- lift_term_at _ t n m raises variables in t which are at least m by n -/
 @[simp] def lift_term_at : ∀ {l}, preterm l → ℕ → ℕ → preterm l
-| _ (var k)       n m := if m ≤ k then var (k+n) else var k
+| _ &k            n m := if m ≤ k then &(k+n) else &k
 | _ (func f)      n m := func f
 | _ (apply t1 t2) n m := apply (lift_term_at t1 n m) (lift_term_at t2 n m)
 
-local notation t ` ↑ `:55 n ` # `:55 m:55 := lift_term_at t n m
+notation t ` ↑ `:100 n ` # `:100 m:100 := _root_.fol.lift_term_at t n m -- input ↑ with \upa
 
 def lift_term (t : term) (n : ℕ) : term := t ↑ n # 0
 def lift_term1 (t : term) : term := t ↑ 1 # 0
 
+infix ` ↑↑ `:100 := _root_.fol.lift_term -- input ↑ with \upa
+postfix ` ↑1`:100 := _root_.fol.lift_term1 -- input ↑ with \upa
+
 lemma lift_term_at_inj : ∀ {l} {t t' : preterm l} {n m : ℕ}, t ↑ n # m = t' ↑ n # m → t = t'
-| _ (var k) (var k')          n m h := 
-  by by_cases h₁ : m ≤ k; by_cases h₂ : m ≤ k'; simp [h₁, h₂] at h; congr; 
-       [exact add_right_cancel h, skip, skip, assumption]; exfalso; 
-       try {apply h₁}; try {apply h₂}; subst h; 
-       apply le_trans (by assumption) (nat.le_add_right _ _)
-| _ (var k) (func f')         n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
-| _ (var k) (apply t1' t2')   n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
-| _ (func f) (var k')         n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
+| _ &k &k' n m h := 
+  by by_cases h₁ : m ≤ k; by_cases h₂ : m ≤ k'; simp [h₁, h₂] at h; 
+     congr;[exact add_right_cancel h, skip, skip, assumption]; exfalso; try {apply h₁}; 
+     try {apply h₂}; subst h; apply le_trans (by assumption) (nat.le_add_right _ _)
+| _ &k (func f')              n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
+| _ &k (apply t1' t2')        n m h := by by_cases h' : m ≤ k; simp [h'] at h; contradiction
+| _ (func f) &k'              n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
 | _ (func f) (func f')        n m h := h
 | _ (func f) (apply t1' t2')  n m h := by cases h
-| _ (apply t1 t2) (var k')    n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
+| _ (apply t1 t2) &k'         n m h := by by_cases h' : m ≤ k'; simp [h'] at h; contradiction
 | _ (apply t1 t2) (func f')   n m h := by cases h
 | _ (apply t1 t2) (apply t1' t2') n m h := 
   begin injection h, congr; apply lift_term_at_inj; assumption end
 
 @[simp] lemma lift_term_at_zero : ∀ {l} (t : preterm l) (m : ℕ), t ↑ 0 # m = t
-| _ (var k)     m := by simp
+| _ &k            m := by simp
 | _ (func f)      m := by refl
 | _ (apply t1 t2) m := by dsimp; congr; apply lift_term_at_zero
 
 /- the following lemmas simplify iterated lifts, depending on the size of m' -/
 lemma lift_term_at2_small : ∀ {l} (t : preterm l) (n n') {m m'}, m' ≤ m → 
   (t ↑ n # m) ↑ n' # m' = (t ↑ n' # m') ↑ n # (m + n')
-| _ (var k)       n n' m m' H := 
+| _ &k            n n' m m' H := 
   begin 
     by_cases h : m ≤ k,
     { have h₁ : m' ≤ k, from le_trans H h,
@@ -72,7 +88,7 @@ lemma lift_term_at2_small : ∀ {l} (t : preterm l) (n n') {m m'}, m' ≤ m →
 
 lemma lift_term_at2_medium : ∀ {l} (t : preterm l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
   (t ↑ n # m) ↑ n' # m' = t ↑ (n+n') # m
-| _ (var k)       n n' m m' H₁ H₂ := 
+| _ &k            n n' m m' H₁ H₂ := 
   begin 
     by_cases h : m ≤ k,
     { have h₁ : m' ≤ k + n, from le_trans H₂ (add_le_add_right h n),
@@ -90,55 +106,69 @@ lemma lift_term_at2_eq {l} (t : preterm l) (n n' m : ℕ) :
 lift_term_at2_medium t n n' (m.le_add_right n) (le_refl _)
 
 lemma lift_term_at2_large {l} (t : preterm l) (n n') {m m'} (H : m' ≥ m + n) : 
-  (t ↑ n # m) ↑ n' # m' = (t ↑ n' # m'-n) ↑ n # m :=
+  (t ↑ n # m) ↑ n' # m' = (t ↑ n' # (m'-n)) ↑ n # m :=
 have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
 have H₂ : m ≤ m' - n, by rw [←nat.add_sub_cancel m n]; apply nat.sub_le_sub_right; exact H,
 begin rw fol.lift_term_at2_small t n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
 
-/- substitute_term t s n substitutes s for (var n) and reduces the level of all variables above n by 1 -/
+/- substitute_term t s n substitutes s for (&n) and reduces the level of all variables above n by 1 -/
 @[simp] def substitute_term : ∀ {l}, preterm l → term → ℕ → preterm l
-| _ (var k)     s n := if k < n then var k else if n < k then var (k-1) else s
+| _ &k            s n := if k < n then &k else if n < k then &(k-1) else s
 | _ (func f)      s n := func f
 | _ (apply t1 t2) s n := apply (substitute_term t1 s n) (substitute_term t2 s n)
 
-@[simp] def substitute_term_var_eq (t : term) (n : ℕ) : substitute_term &n t n = t :=
+notation t `[`:95 s ` // `:95 n `]`:0 := _root_.fol.substitute_term t s n
+
+@[simp] def substitute_term_var_eq (t : term) (n : ℕ) : &n[t // n] = t :=
 by simp [lt_irrefl]
 
-lemma substitute_term_lift_term' : ∀{l} (t : preterm l) (s : term), 
-  substitute_term (lift_term_at t 1 0) s 0 = t :=
+lemma substitute_term_lift_term' : ∀{l} (t : preterm l) (s : term) (n : ℕ), 
+  (lift_term_at t 1 n)[s // n] = t :=
 sorry
 
-@[simp] lemma substitute_term_lift_term (t s : term) : substitute_term (lift_term1 t) s 0 = t :=
-substitute_term_lift_term' t s
+@[simp] lemma substitute_term_lift_term (t s : term) : (lift_term1 t)[s // 0] = t :=
+substitute_term_lift_term' t s 0
 
-/- preformula n is a partially applied formula. if applied to n terms, it becomes a formula -/
+/- preformula n is a partially applied formula. if applied to n terms, it becomes a formula. 
+  * We only have implication as binary connective. Since we use classical logic, we can define
+    the other connectives from implication and false. 
+  * Similarly, universal quantification is our only quantifier. 
+  * We could make `false` and `equal` into elements of rel. However, if we do that, then we cannot make the interpretation of them in a model definitionally what we want.
+
+-/
 inductive preformula : ℕ → Type 
+| false : preformula 0
+| equal : term → term → preformula 0
 | rel : ∀ {n : nat}, L.relations n → preformula n
 | apprel : ∀ {n : nat}, preformula (n + 1) → term → preformula n
 | imp : preformula 0 → preformula 0 → preformula 0
 | all : preformula 0 → preformula 0
 open preformula
-def formula := preformula 0
+@[reducible] def formula := preformula 0
 
-def equal (t₁ t₂ : term) : formula := apprel (apprel (rel L.equal) t₁) t₂
-def false : formula := rel L.false
 def not (f : formula) : formula := imp f false
-def or (f₁ f₂ : formula) : formula := imp (not f₁) f₂
 def and (f₁ f₂ : formula) : formula := not (imp f₁ (not f₂))
+def or (f₁ f₂ : formula) : formula := imp (not f₁) f₂
 def iff (f₁ f₂ : formula) : formula := and (imp f₁ f₂) (imp f₂ f₁)
 def ex (f : formula) : formula := not (all (not f))
 
-local infix ` ⟾ `:70 := imp
-local infix ` ⇔ `:75 := iff
-local infix ` ≍ `:80 := equal
+notation `⊥` := _root_.fol.preformula.false -- input: \bot
+infix ` ≃ `:90 := _root_.fol.preformula.equal -- input \~- or \simeq
+infix ` ⟹ `:70 := _root_.fol.preformula.imp -- input \==>
+prefix `~` := _root_.fol.not
+infixr ` ⊔ `:80 := _root_.fol.or -- input: \sqcup
+infixr ` ⊓ `:85 := _root_.fol.and -- input: \sqcap
+
 
 @[simp] def lift_formula_at : ∀ {l}, preformula l → ℕ → ℕ → preformula l
+| _ false        n m := false
+| _ (t1 ≃ t2)    n m := equal (lift_term_at t1 n m) (lift_term_at t2 n m)
 | _ (rel R)      n m := rel R
 | _ (apprel f t) n m := apprel (lift_formula_at f n m) (lift_term_at t n m)
 | _ (imp f1 f2)  n m := imp (lift_formula_at f1 n m) (lift_formula_at f2 n m)
 | _ (all f)      n m := all (lift_formula_at f n (m+1))
 
-local notation f ` ↑ `:55 n ` # `:55 m:55 := lift_formula_at f n m
+notation f ` ↑ `:100 n ` # `:100 m:100 := _root_.fol.lift_formula_at f n m -- input ↑ with \upa
 
 def lift_formula (f : formula) (n : ℕ) : formula := f ↑ n # 0
 def lift_formula1 (f : formula) : formula := f ↑ 1 # 0
@@ -146,12 +176,15 @@ def lift_formula1 (f : formula) : formula := f ↑ 1 # 0
 lemma lift_formula_at_inj {l} {f f' : preformula l} {n m : ℕ} (H : f ↑ n # m = f' ↑ n # m) : f = f' :=
 begin
   induction f generalizing m; cases f'; injection H,
+  simp [lift_term_at_inj h_1, lift_term_at_inj h_2],
   simp [f_ih h_1, fol.lift_term_at_inj h_2],
   simp [f_ih_a h_1, f_ih_a_1 h_2],
   simp [f_ih h_1]
 end
 
 @[simp] lemma lift_formula_at_zero : ∀ {l} (f : preformula l) (m : ℕ), f ↑ 0 # m = f
+| _ false        m := by refl
+| _ (t1 ≃ t2)    m := by simp
 | _ (rel R)      m := by refl
 | _ (apprel f t) m := by simp; apply lift_formula_at_zero
 | _ (imp f1 f2)  m := by dsimp; congr1; apply lift_formula_at_zero
@@ -160,6 +193,8 @@ end
 /- the following lemmas simplify iterated lifts, depending on the size of m' -/
 lemma lift_formula_at2_small : ∀ {l} (f : preformula l) (n n') {m m'}, m' ≤ m → 
   (f ↑ n # m) ↑ n' # m' = (f ↑ n' # m') ↑ n # (m + n')
+| _ false        n n' m m' H := by refl
+| _ (t1 ≃ t2)    n n' m m' H := by simp [lift_term_at2_small, H]
 | _ (rel R)      n n' m m' H := by refl
 | _ (apprel f t) n n' m m' H := 
   by simp [lift_term_at2_small, H, -add_comm]; apply lift_formula_at2_small; assumption
@@ -169,6 +204,8 @@ lemma lift_formula_at2_small : ∀ {l} (f : preformula l) (n n') {m m'}, m' ≤ 
 
 lemma lift_formula_at2_medium : ∀ {l} (f : preformula l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
   (f ↑ n # m) ↑ n' # m' = f ↑ (n+n') # m
+| _ false        n n' m m' H₁ H₂ := by refl
+| _ (t1 ≃ t2)    n n' m m' H₁ H₂ := by simp [lift_term_at2_medium, H₁, H₂]
 | _ (rel R)      n n' m m' H₁ H₂ := by refl
 | _ (apprel f t) n n' m m' H₁ H₂ :=
   by simp [lift_term_at2_medium, H₁, H₂, -add_comm]; apply lift_formula_at2_medium; assumption
@@ -182,55 +219,145 @@ lemma lift_formula_at2_eq {l} (f : preformula l) (n n' m : ℕ) :
 lift_formula_at2_medium f n n' (m.le_add_right n) (le_refl _)
 
 lemma lift_formula_at2_large {l} (f : preformula l) (n n') {m m'} (H : m' ≥ m + n) : 
-  (f ↑ n # m) ↑ n' # m' = (f ↑ n' # m'-n) ↑ n # m :=
+  (f ↑ n # m) ↑ n' # m' = (f ↑ n' # (m'-n)) ↑ n # m :=
 have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
 have H₂ : m ≤ m' - n, by rw [←nat.add_sub_cancel m n]; apply nat.sub_le_sub_right; exact H,
 begin rw fol.lift_formula_at2_small f n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
 
 @[simp] def substitute_formula : ∀ {l}, preformula l → term → ℕ → preformula l
+| _ false        s n := false
+| _ (t1 ≃ t2)    s n := equal (substitute_term t1 s n) (substitute_term t2 s n)
 | _ (rel R)      s n := rel R
 | _ (apprel f t) s n := apprel (substitute_formula f s n) (substitute_term t s n)
 | _ (imp f1 f2)  s n := imp (substitute_formula f1 s n) (substitute_formula f2 s n)
 | _ (all f)      s n := all (substitute_formula f s (n+1))
 
-@[simp] def substitute_formula0 (f : formula) (t : term) := substitute_formula f t 0
+notation f `[`:95 s ` // `:95 n `]`:0 := _root_.fol.substitute_formula f s n
 
 @[simp] def substitute_formula_equal (t₁ t₂ s : term) (n : ℕ) :
-  substitute_formula (t₁ ≍ t₂) s n = substitute_term t₁ s n ≍ substitute_term t₂ s n :=
+  (t₁ ≃ t₂)[s // n] = t₁[s // n] ≃ (t₂[s // n]) :=
 by refl
 
--- ⟾⇔≍
-
+-- ⟹⇔≃
+/- Provability relation
+* to decide: should Γ be a list or a set (or finset)?
+* We use natural deduction as our deduction system, since that is most convenient to work with.
+* All rules are motivated to work well with backwards reasoning.
+-/
 inductive prf : list formula → formula → Type
 | axm    : ∀{Γ A}, A ∈ Γ → prf Γ A
-| impI   : ∀{Γ A B}, prf (A::Γ) B → prf Γ (A ⟾ B)
-| impE   : ∀{Γ A B}, prf Γ (A ⟾ B) → prf Γ A → prf Γ B
+| impI   : ∀{Γ A B}, prf (A::Γ) B → prf Γ (A ⟹ B)
+| impE   : ∀{Γ} (A) {B}, prf Γ (A ⟹ B) → prf Γ A → prf Γ B
 | falseE : ∀{Γ A}, prf (not A::Γ) false → prf Γ A
-| allI   : ∀{Γ A}, prf (list.map lift_formula1 Γ) A → prf Γ (all A)
-| allE   : ∀{Γ} A t, prf Γ (all A) → prf Γ (substitute_formula0 A t)
-| refl   : ∀Γ t, prf Γ (t ≍ t)
-| subst : ∀{Γ} s t f, prf Γ (s ≍ t) → prf Γ (substitute_formula f s 0) → 
-  prf Γ (substitute_formula f t 0)
+| allI   : ∀{Γ A}, prf (map lift_formula1 Γ) A → prf Γ (all A)
+| allE'  : ∀{Γ} A t, prf Γ (all A) → prf Γ (A[t // 0])
+| refl   : ∀Γ t, prf Γ (t ≃ t)
+| subst' : ∀{Γ} s t f, prf Γ (s ≃ t) → prf Γ (f[s // 0]) → prf Γ (f[t // 0])
 open prf
-local infix ` ⊢ `:51 := prf
+infix ` ⊢ `:51 := _root_.fol.prf -- input: \|- or \vdash
 
-def symm {Γ s t} (H : Γ ⊢ s ≍ t) : Γ ⊢ t ≍ s :=
-begin 
-  have H₁ := subst s t (equal (var 0) (lift_term1 s)) H, -- why does notation not work here?
-  rw [substitute_formula_equal, substitute_formula_equal, substitute_term_lift_term, substitute_term_lift_term, substitute_term_var_eq, substitute_term_var_eq] at H₁,
-  exact H₁ (refl Γ s)
+def weakening {Γ Δ} {f : formula} (H₁ : Γ ⊆ Δ) (H₂ : Γ ⊢ f) : Δ ⊢ f :=
+begin
+  induction H₂ generalizing Δ,
+  { apply axm, exact H₁ H₂_a, },
+  { apply impI, apply H₂_ih, simp [cons_subset_cons, H₁] },
+  { apply impE, apply H₂_ih_a, assumption, apply H₂_ih_a_1, assumption },
+  { apply falseE, apply H₂_ih, simp [cons_subset_cons, H₁] },
+  { apply allI, apply H₂_ih, sorry /-simp [cons_subset_cons, H₁]-/ },
+  { apply allE', apply H₂_ih, assumption },
+  { apply refl },
+  { apply subst', apply H₂_ih_a, assumption, apply H₂_ih_a_1, assumption },
 end
 
-def trans {Γ t₁ t₂ t₃} (H : Γ ⊢ t₁ ≍ t₂) (H' : Γ ⊢ t₂ ≍ t₃) : Γ ⊢ t₁ ≍ t₃ :=
+def weakening_cons {Γ} {f₁ f₂ : formula} (H : Γ ⊢ f₂) : f₁::Γ ⊢ f₂ :=
+weakening (Γ.subset_cons f₁) H
+
+def weakening_cons2 {Γ} {f₁ f₂ f₃ : formula} (H : f₁::Γ ⊢ f₂) : f₁::f₃::Γ ⊢ f₂ :=
+weakening (cons_subset_cons _ (Γ.subset_cons _)) H
+
+def allE {Γ} (A : formula) (t) {B} (H₁ : prf Γ (all A)) (H₂ : A[t // 0] = B) : prf Γ B :=
+by induction H₂; exact allE' A t H₁
+
+def subst {Γ} {s t} (f₁ : formula) {f₂} (H₁ : prf Γ (s ≃ t)) (H₂ : prf Γ (f₁[s // 0])) 
+  (H₃ : f₁[t // 0] = f₂) : prf Γ f₂ :=
+by induction H₃; exact subst' s t f₁ H₁ H₂
+
+def axm1 {Γ} {A : formula} : A::Γ ⊢ A := by apply axm; left; refl
+def axm2 {Γ} {A B : formula} : A::B::Γ ⊢ B := by apply axm; right; left; refl
+
+def deduction {Γ} {A B : formula} (H : Γ ⊢ A ⟹ B) : A::Γ ⊢ B :=
+impE A (weakening_cons H) axm1
+
+def exfalso {Γ} {A : formula} (H : prf Γ false) : prf Γ A :=
+falseE (weakening_cons H)
+
+def andI {Γ} {f₁ f₂ : formula} (H₁ : Γ ⊢ f₁) (H₂ : Γ ⊢ f₂) : Γ ⊢ f₁ ⊓ f₂ :=
 begin 
-  have H₁ := prf.subst t₂ t₃ (equal (lift_term1 t₁) (var 0)) H', 
-  rw [substitute_formula_equal, substitute_formula_equal, substitute_term_lift_term, substitute_term_lift_term, substitute_term_var_eq, substitute_term_var_eq] at H₁,
-  exact H₁ H
+  apply impI, apply impE f₂,
+  { apply impE f₁, apply axm1, exact weakening_cons H₁ },
+  { exact weakening_cons H₂ }
+end
+
+def andE1 {Γ f₁} (f₂ : formula) (H : Γ ⊢ f₁ ⊓ f₂) : Γ ⊢ f₁ :=
+begin 
+  apply falseE, apply impE _ (weakening_cons H), apply impI, apply exfalso,
+  apply impE f₁; [apply axm2, apply axm1]
+end
+
+def andE2 {Γ} (f₁ : formula) {f₂} (H : Γ ⊢ f₁ ⊓ f₂) : Γ ⊢ f₂ :=
+begin 
+  apply falseE, apply impE _ (weakening_cons H), apply impI, apply axm2
+end
+
+def orI1 {Γ} {A B : formula} (H : Γ ⊢ A) : Γ ⊢ A ⊔ B :=
+begin
+  apply impI, apply exfalso, refine impE _ _ (weakening_cons H), apply axm1
+end
+
+def orI2 {Γ} {A B : formula} (H : Γ ⊢ B) : Γ ⊢ A ⊔ B :=
+impI $ weakening_cons H
+
+def orE {Γ} {A B C : formula} (H₁ : Γ ⊢ A ⊔ B) (H₂ : A::Γ ⊢ C) (H₃ : B::Γ ⊢ C) : Γ ⊢ C :=
+begin
+  apply falseE, apply impE C, { apply axm1 },
+  apply impE B, { apply impI, exact weakening_cons2 H₃ },
+  apply impE _ (weakening_cons H₁),
+  apply impI (impE _ axm2 (weakening_cons2 H₂))
+end
+
+def iffI {Γ} {f₁ f₂ : formula} (H₁ : f₁::Γ ⊢ f₂) (H₂ : f₂::Γ ⊢ f₁) : Γ ⊢ iff f₁ f₂ :=
+by apply andI; apply impI; assumption
+
+def iffE1 {Γ} {f₁ f₂ : formula} (H : Γ ⊢ iff f₁ f₂) : f₁::Γ ⊢ f₂ :=
+deduction (andE1 _ H)
+
+def iffE2 {Γ} {f₁ f₂ : formula} (H : Γ ⊢ iff f₁ f₂) : f₂::Γ ⊢ f₁ :=
+deduction (andE2 _ H)
+
+-- def ex (f : formula) : formula := not (all (not f))
+
+def symm {Γ} {s t : term} (H : Γ ⊢ s ≃ t) : Γ ⊢ t ≃ s :=
+begin 
+  apply subst (&0 ≃ s ↑1) H; 
+    rw [substitute_formula_equal, substitute_term_lift_term, substitute_term_var_eq],
+  apply refl
+end
+
+def trans {Γ} {t₁ t₂ t₃ : term} (H : Γ ⊢ t₁ ≃ t₂) (H' : Γ ⊢ t₂ ≃ t₃) : Γ ⊢ t₁ ≃ t₃ :=
+begin 
+  apply subst (t₁ ↑1 ≃ &0) H';
+    rw [substitute_formula_equal, substitute_term_lift_term, substitute_term_var_eq],
+  exact H
+end
+
+def congr {Γ} {t₁ t₂ s : term} (H : Γ ⊢ t₁ ≃ t₂) : Γ ⊢ s[t₁ // 0] ≃ s[t₂ // 0] :=
+begin 
+  apply subst (s[t₁ // 0] ↑1 ≃ s) H, 
+  { rw [substitute_formula_equal, substitute_term_lift_term], apply refl },
+  { rw [substitute_formula_equal, substitute_term_lift_term] }
 end
 
 end
 end fol
 open fol fol.preterm
 variable {L : Language}
-#check substitute_formula0 (@equal L (var 0) (var 0)) (var 7)
-#reduce substitute_formula0 (@equal L (var 0) (var 0)) (var 7)

--- a/leanpkg.path
+++ b/leanpkg.path
@@ -1,2 +1,3 @@
 builtin_path
+path ./../mathlib/.
 path ./src

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,3 +5,4 @@ lean_version = "nightly-2018-04-20"
 path = "src"
 
 [dependencies]
+mathlib = {path = "../mathlib"}


### PR DESCRIPTION
Here is a proof of (a version of) soundness of first-order logic.

Some notes:
* This file depends on mathlib. Currently, it requires a compiled version of mathlib in the parent directory of `flypitch`. I don't think this is the best way to do this, so maybe you don't want to merge this yet.
* I define satisfaction for formulae, not just sentences. This makes the formulation/proof of soundness easier, and the definition is equivalent (but not literally the same) as the usual definition if you only use sentences.