### PR TITLE
adding dfin, is_bounded_preterm

### DIFF
--- a/src/fol.lean
+++ b/src/fol.lean
@@ -25,11 +25,11 @@ if k < n then v k else if n < k then v (k - 1) else x
 notation v `[`:95 x ` // `:95 n `]`:0 := fol.subst_realize v x n
 
 /-- --/
-@[simp] lemma subst_realize_lt {S : Type u} (v : ℕ → S) (x : S) {n k : ℕ} (H : k < n) : 
+@[simp] lemma subst_realize_lt {S : Type u} (v : ℕ → S) (x : S) {n k : ℕ} (H : k < n) :
   v[x // n] k = v k :=
 by simp only [H, subst_realize, if_true, eq_self_iff_true]
 
-@[simp] lemma subst_realize_gt {S : Type u} (v : ℕ → S) (x : S) {n k : ℕ} (H : n < k) : 
+@[simp] lemma subst_realize_gt {S : Type u} (v : ℕ → S) (x : S) {n k : ℕ} (H : n < k) :
   v[x // n] k = v (k-1) :=
 have h : ¬(k < n), from lt_asymm H,
 by simp only [*, subst_realize, if_true, eq_self_iff_true, if_false]
@@ -37,9 +37,9 @@ by simp only [*, subst_realize, if_true, eq_self_iff_true, if_false]
 @[simp] lemma subst_realize_var_eq {S : Type u} (v : ℕ → S) (x : S) (n : ℕ) : v[x // n] n = x :=
 by simp only [subst_realize, lt_irrefl, eq_self_iff_true, if_false]
 
-lemma subst_realize_congr {S : Type u} {v v' : ℕ → S} (hv : ∀k, v k = v' k) (x : S) (n k : ℕ) : 
+lemma subst_realize_congr {S : Type u} {v v' : ℕ → S} (hv : ∀k, v k = v' k) (x : S) (n k : ℕ) :
  v [x // n] k = v' [x // n] k :=
-by apply lt_by_cases k n; intro h; 
+by apply lt_by_cases k n; intro h;
    simp only [*, subst_realize_lt, subst_realize_gt, subst_realize_var_eq, eq_self_iff_true]
 
 lemma subst_realize2 {S : Type u} (v : ℕ → S) (x x' : S) (n₁ n₂ k : ℕ) :
@@ -52,10 +52,10 @@ begin
     { have : k < n₂ + (k + 1), from nat.lt_add_left _ _ n₂ (lt.base k),
       subst h, simp [*, -add_comm] },
     apply lt_by_cases k (n₁ + n₂ + 1); intro h',
-    { have : k - 1 < n₁ + n₂, from (nat.sub_lt_right_iff_lt_add (one_le_of_lt h)).2 h', 
+    { have : k - 1 < n₁ + n₂, from (nat.sub_lt_right_iff_lt_add (one_le_of_lt h)).2 h',
       simp [*, -add_comm, -add_assoc] },
     { subst h', simp [h, -add_comm, -add_assoc] },
-    { have : n₁ + n₂ < k - 1, from nat.lt_sub_right_of_add_lt h', 
+    { have : n₁ + n₂ < k - 1, from nat.lt_sub_right_of_add_lt h',
       have : n₁ < k - 1, from lt_of_le_of_lt (n₁.le_add_right n₂) this,
       simp only [*, fol.subst_realize_gt, eq_self_iff_true] }
 end
@@ -70,23 +70,23 @@ begin
   cases k, refl, have h : 0 < succ k, from zero_lt_succ k, simp [h, hv k (lt_of_succ_lt_succ hk)]
 end
 
-lemma lift_subst_realize_cancel {S : Type u} (v : ℕ → S) (k : ℕ) : 
+lemma lift_subst_realize_cancel {S : Type u} (v : ℕ → S) (k : ℕ) :
   (λn, v (n + 1))[v 0 // 0] k = v k :=
 begin
   cases k, refl, have h : 0 < succ k, from zero_lt_succ k, simp [h],
 end
 
-lemma subst_fin_realize_eq {S : Type u} {n} {v₁ : dvector S n} {v₂ : ℕ → S} 
-  (hv : ∀k (hk : k < n), v₁.nth k hk = v₂ k) (x : S) (k : ℕ) (hk : k < n+1) : 
+lemma subst_fin_realize_eq {S : Type u} {n} {v₁ : dvector S n} {v₂ : ℕ → S}
+  (hv : ∀k (hk : k < n), v₁.nth k hk = v₂ k) (x : S) (k : ℕ) (hk : k < n+1) :
     (x::v₁).nth k hk = v₂[x // 0] k :=
 begin
-  cases k, refl, 
-  have h : 0 < succ k, from zero_lt_succ k, 
-  have h' : (0 : fin (n+1)).val < (fin.mk (succ k) hk).val, from h, 
-  rw [subst_realize_gt v₂ x h, dvector.nth], apply hv 
+  cases k, refl,
+  have h : 0 < succ k, from zero_lt_succ k,
+  have h' : (0 : fin (n+1)).val < (fin.mk (succ k) hk).val, from h,
+  rw [subst_realize_gt v₂ x h, dvector.nth], apply hv
 end
 
-structure Language : Type (u+1) := 
+structure Language : Type (u+1) :=
 (functions : ℕ → Type u) (relations : ℕ → Type u)
 
 def Language.constants (L : Language) := L.functions 0
@@ -94,7 +94,7 @@ def Language.constants (L : Language) := L.functions 0
 variable (L : Language.{u})
 
 /- preterm L l is a partially applied term. if applied to n terms, it becomes a term.
-* Every element of preterm L 0 is a well-formed term. 
+* Every element of preterm L 0 is a well-formed term.
 * We use this encoding to avoid mutual or nested inductive types, since those are not too convenient to work with in Lean. -/
 inductive preterm : ℕ → Type u
 | var {} : ∀ (k : ℕ), preterm 0
@@ -124,7 +124,7 @@ by cases ts; refl
 
 lemma apps_eq_app {l} (t : preterm L (l+1)) (s : term L) (ts : dvector (term L) l) :
   ∃t' s', apps t (s::ts) = app t' s' :=
-begin 
+begin
   induction ts generalizing s, exact ⟨t, s, rfl⟩, exact ts_ih (app t s) ts_x
 end
 
@@ -143,40 +143,40 @@ end preterm
 
 -- lemma apps'_concat {l l'} (t : preterm L (l'+(l+1))) (s : term L) (ts : dvector (term L) l) :
 --   apps' t (ts.concat s) = app (apps' (t.change_arity' (by simp)) ts) s :=
--- begin 
---   induction ts generalizing s, 
---   { simp }, 
+-- begin
+--   induction ts generalizing s,
+--   { simp },
 --   { apply ts_ih (app t ts_x) s }
 -- end
 
 lemma apps_ne_var {l} {f : L.functions l} {ts : dvector (term L) l} {k : ℕ} :
   apps (func f) ts ≠ &k :=
 begin
-  intro h, cases ts, injection h, 
+  intro h, cases ts, injection h,
   rcases apps_eq_app (func f) ts_x ts_xs with ⟨t, s, h'⟩, cases h.symm.trans h'
 end
 
-lemma apps_inj' {l} {t t' : preterm L l} {ts ts' : dvector (term L) l} 
+lemma apps_inj' {l} {t t' : preterm L l} {ts ts' : dvector (term L) l}
   (h : apps t ts = apps t' ts') : t = t' ∧ ts = ts' :=
 begin
-  induction ts; cases ts', 
+  induction ts; cases ts',
   { exact ⟨h, rfl⟩ },
   { rcases ts_ih h with ⟨⟨rfl, rfl⟩, rfl⟩, exact ⟨rfl, rfl⟩ }
 end
 
--- lemma apps_inj_length {l l'} {f : L.functions l} {f' : L.functions l'} 
---   {ts : dvector (term L) l} {ts' : dvector (term L) l'} 
+-- lemma apps_inj_length {l l'} {f : L.functions l} {f' : L.functions l'}
+--   {ts : dvector (term L) l} {ts' : dvector (term L) l'}
 --   (h : apps (func f) ts = apps (func f') ts') : l = l' :=
 -- begin
 --   sorry
 -- end
 
--- lemma apps'_inj_length {l₁ l₂ l'} {f : L.functions (l' + l₁)} {f' : L.functions (l' + l₂)} 
---   {ts : dvector (term L) l₁} {ts' : dvector (term L) l₂} 
+-- lemma apps'_inj_length {l₁ l₂ l'} {f : L.functions (l' + l₁)} {f' : L.functions (l' + l₂)}
+--   {ts : dvector (term L) l₁} {ts' : dvector (term L) l₂}
 --   (h : apps' (func f) ts = apps' (func f') ts') : l₁ = l₂ :=
 -- begin
 --   sorry
---   -- induction ts generalizing l'; cases ts', 
+--   -- induction ts generalizing l'; cases ts',
 --   -- { refl },
 --   -- { rcases apps'_eq_app (func f') ts'_x ts'_xs with ⟨t, s, h'⟩, cases h.trans h' },
 --   -- { rcases apps'_eq_app (func f) ts_x ts_xs with ⟨t, s, h'⟩, cases h.symm.trans h' },
@@ -185,7 +185,7 @@ end
 --   --    }
 -- end
 
-lemma apps_inj {l} {f f' : L.functions l} {ts ts' : dvector (term L) l} 
+lemma apps_inj {l} {f f' : L.functions l} {ts ts' : dvector (term L) l}
   (h : apps (func f) ts = apps (func f') ts') : f = f' ∧ ts = ts' :=
 by rcases apps_inj' h with ⟨h', rfl⟩; cases h'; exact ⟨rfl, rfl⟩
 
@@ -194,16 +194,16 @@ arity'.of_dvector_map $ apps (func f)
 
 @[elab_as_eliminator] def term.rec {C : term L → Sort v}
   (hvar : ∀(k : ℕ), C &k)
-  (hfunc : Π {l} (f : L.functions l) (ts : dvector (term L) l) (ih_ts : ∀t, ts.pmem t → C t), 
+  (hfunc : Π {l} (f : L.functions l) (ts : dvector (term L) l) (ih_ts : ∀t, ts.pmem t → C t),
     C (apps (func f) ts)) : ∀(t : term L), C t :=
-have h : ∀{l} (t : preterm L l) (ts : dvector (term L) l) (ih_ts : ∀s, ts.pmem s → C s), 
+have h : ∀{l} (t : preterm L l) (ts : dvector (term L) l) (ih_ts : ∀s, ts.pmem s → C s),
   C (apps t ts),
 begin
   intros, induction t; try {rw ts.zero_eq},
-  { apply hvar }, 
-  { apply hfunc t_f ts ih_ts }, 
-  { apply t_ih_t (t_s::ts), intros t ht, 
-    cases ht, 
+  { apply hvar },
+  { apply hfunc t_f ts ih_ts },
+  { apply t_ih_t (t_s::ts), intros t ht,
+    cases ht,
     { induction ht, apply t_ih_s ([]), intros s hs, cases hs },
     { exact ih_ts t ht }},
 end,
@@ -211,7 +211,7 @@ end,
 
 @[elab_as_eliminator] def term.elim' {C : Type v}
   (hvar : ∀(k : ℕ), C)
-  (hfunc : Π {{l}} (f : L.functions l) (ts : dvector (term L) l) (ih_ts : dvector C l), C) : 
+  (hfunc : Π {{l}} (f : L.functions l) (ts : dvector (term L) l) (ih_ts : dvector C l), C) :
   ∀{l} (t : preterm L l) (ts : dvector (term L) l) (ih_ts : dvector C l), C
 | _ &k ts ih_ts        := hvar k
 | _ (func f) ts ih_ts  := hfunc f ts ih_ts
@@ -219,7 +219,7 @@ end,
 
 @[elab_as_eliminator] def term.elim {C : Type v}
   (hvar : ∀(k : ℕ), C)
-  (hfunc : Π {{l}} (f : L.functions l) (ts : dvector (term L) l) (ih_ts : dvector C l), C) : 
+  (hfunc : Π {{l}} (f : L.functions l) (ts : dvector (term L) l) (ih_ts : dvector C l), C) :
   ∀(t : term L), C :=
 λt, term.elim' hvar hfunc t ([]) ([])
 
@@ -227,7 +227,7 @@ lemma term.elim'_apps {C : Type v}
   (hvar : ∀(k : ℕ), C)
   (hfunc : Π {{l}} (f : L.functions l) (ts : dvector (term L) l) (ih_ts : dvector C l), C)
   {l} (t : preterm L l) (ts : dvector (term L) l) :
-  @term.elim' L C hvar hfunc 0 (apps t ts) ([]) ([]) = @term.elim' L C hvar hfunc l t ts 
+  @term.elim' L C hvar hfunc 0 (apps t ts) ([]) ([]) = @term.elim' L C hvar hfunc l t ts
   (ts.map $ term.elim hvar hfunc) :=
 begin
   induction ts,
@@ -253,7 +253,7 @@ notation t ` ↑' `:90 n ` # `:90 m:90 := fol.lift_term_at t n m -- input ↑ wi
 -- @[simp] lemma lift_term_var_le {k n m} (h : m ≤ k) : &k ↑' n # m = (&(k+n) : term L) := dif_pos h
 -- @[simp] lemma lift_term_var_gt {k n m} (h : ¬(m ≤ k)) : &k ↑' n # m = (&k : term L) := dif_neg h
 -- @[simp] lemma lift_term_at_func {l} (f : L.functions l) (n m) : func f ↑' n # m = func f := by refl
--- @[simp] lemma lift_term_at_app {l} (t : preterm L (l+1)) (s : preterm L 0) (n m) : 
+-- @[simp] lemma lift_term_at_app {l} (t : preterm L (l+1)) (s : preterm L 0) (n m) :
 --   app t s ↑' n # m = app (t ↑' n # m) (s ↑' n # m) := by refl
 
 @[reducible] def lift_term {l} (t : preterm L l) (n : ℕ) : preterm L l := t ↑' n # 0
@@ -262,11 +262,11 @@ infix ` ↑ `:100 := fol.lift_term -- input ↑' with \u or \upa
 
 @[simp] lemma lift_term_def {l} (t : preterm L l) (n : ℕ) : t ↑' n # 0 = t ↑ n := by refl
 
-lemma injective_lift_term_at : ∀ {l} {n m : ℕ}, 
+lemma injective_lift_term_at : ∀ {l} {n m : ℕ},
   function.injective (λ(t : preterm L l), lift_term_at t n m)
-| _ n m &k &k' h := 
+| _ n m &k &k' h :=
   by by_cases h₁ : m ≤ k; by_cases h₂ : m ≤ k'; simp [h₁, h₂] at h;
-     congr;[assumption, skip, skip, assumption]; exfalso; try {apply h₁}; 
+     congr;[assumption, skip, skip, assumption]; exfalso; try {apply h₁};
      try {apply h₂}; subst h; apply le_trans (by assumption) (le_add_left _ _)
 | _ n m &k (func f')            h := by cases h
 | _ n m &k (app t₁' t₂')        h := by cases h
@@ -275,7 +275,7 @@ lemma injective_lift_term_at : ∀ {l} {n m : ℕ},
 | _ n m (func f) (app t₁' t₂')  h := by cases h
 | _ n m (app t₁ t₂) &k'         h := by cases h
 | _ n m (app t₁ t₂) (func f')   h := by cases h
-| _ n m (app t₁ t₂) (app t₁' t₂') h := 
+| _ n m (app t₁ t₂) (app t₁' t₂') h :=
   begin injection h, congr; apply injective_lift_term_at; assumption end
 
 @[simp] lemma lift_term_at_zero : ∀ {l} (t : preterm L l) (m : ℕ), t ↑' 0 # m = t
@@ -286,10 +286,10 @@ lemma injective_lift_term_at : ∀ {l} {n m : ℕ},
 @[simp] lemma lift_term_zero {l} (t : preterm L l) : t ↑ 0 = t := lift_term_at_zero t 0
 
 /- the following lemmas simplify iterated lifts, depending on the size of m' -/
-lemma lift_term_at2_small : ∀ {l} (t : preterm L l) (n n') {m m'}, m' ≤ m → 
+lemma lift_term_at2_small : ∀ {l} (t : preterm L l) (n n') {m m'}, m' ≤ m →
   (t ↑' n # m) ↑' n' # m' = (t ↑' n' # m') ↑' n # (m + n')
-| _ &k          n n' m m' H := 
-  begin 
+| _ &k          n n' m m' H :=
+  begin
     by_cases h : m ≤ k,
     { have h₁ : m' ≤ k := le_trans H h,
       have h₂ : m' ≤ k + n, from le_trans h₁ (k.le_add_right n),
@@ -299,19 +299,19 @@ lemma lift_term_at2_small : ∀ {l} (t : preterm L l) (n n') {m m'}, m' ≤ m �
       by_cases h' : m' ≤ k; simp [*, -add_comm, -add_assoc] }
   end
 | _ (func f)    n n' m m' H := by refl
-| _ (app t₁ t₂) n n' m m' H := 
+| _ (app t₁ t₂) n n' m m' H :=
   begin dsimp; congr1; apply lift_term_at2_small; assumption end
 
-lemma lift_term_at2_medium : ∀ {l} (t : preterm L l) {n} (n') {m m'}, m ≤ m' → m' ≤ m+n → 
+lemma lift_term_at2_medium : ∀ {l} (t : preterm L l) {n} (n') {m m'}, m ≤ m' → m' ≤ m+n →
   (t ↑' n # m) ↑' n' # m' = t ↑' (n+n') # m
-| _ &k          n n' m m' H₁ H₂ := 
-  begin 
+| _ &k          n n' m m' H₁ H₂ :=
+  begin
     by_cases h : m ≤ k,
     { have h₁ : m' ≤ k + n, from le_trans H₂ (add_le_add_right h n), simp [*, -add_comm], },
     { have h₁ : ¬m' ≤ k, from λ h', h (le_trans H₁ h'), simp [*, -add_comm, -add_assoc] }
   end
 | _ (func f)    n n' m m' H₁ H₂ := by refl
-| _ (app t₁ t₂) n n' m m' H₁ H₂ := 
+| _ (app t₁ t₂) n n' m m' H₁ H₂ :=
   begin dsimp; congr1; apply lift_term_at2_medium; assumption end
 
 lemma lift_term2_medium {l} (t : preterm L l) {n} (n') {m'} (h : m' ≤ n) :
@@ -321,24 +321,24 @@ lift_term_at2_medium t n' m'.zero_le (by simp*)
 lemma lift_term2 {l} (t : preterm L l) (n n') : (t ↑ n) ↑ n' = t ↑ (n+n') :=
 lift_term2_medium t n' n.zero_le
 
-lemma lift_term_at2_eq {l} (t : preterm L l) (n n' m : ℕ) : 
+lemma lift_term_at2_eq {l} (t : preterm L l) (n n' m : ℕ) :
   (t ↑' n # m) ↑' n' # (m+n) = t ↑' (n+n') # m :=
 lift_term_at2_medium t n' (m.le_add_right n) (le_refl _)
 
-lemma lift_term_at2_large {l} (t : preterm L l) {n} (n') {m m'} (H : m + n ≤ m') : 
+lemma lift_term_at2_large {l} (t : preterm L l) {n} (n') {m m'} (H : m + n ≤ m') :
   (t ↑' n # m) ↑' n' # m' = (t ↑' n' # (m'-n)) ↑' n # m :=
 have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
 have H₂ : m ≤ m' - n, from nat.le_sub_right_of_add_le H,
 begin rw fol.lift_term_at2_small t n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
 
-@[simp] lemma lift_term_var0 (n : ℕ) : &0 ↑ n = (&n : term L) := 
+@[simp] lemma lift_term_var0 (n : ℕ) : &0 ↑ n = (&n : term L) :=
 by have h : 0 ≤ 0 := le_refl 0; rw [←lift_term_def]; simp [h, -lift_term_def]
 
-@[simp] lemma lift_term_at_apps {l} (t : preterm L l) (ts : dvector (term L) l) (n m : ℕ) : 
+@[simp] lemma lift_term_at_apps {l} (t : preterm L l) (ts : dvector (term L) l) (n m : ℕ) :
   (apps t ts) ↑' n # m = apps (t ↑' n # m) (ts.map $ λx, x ↑' n # m) :=
 by induction ts generalizing t;[refl, apply ts_ih (app t ts_x)]
 
-@[simp] lemma lift_term_apps {l} (t : preterm L l) (ts : dvector (term L) l) (n : ℕ) : 
+@[simp] lemma lift_term_apps {l} (t : preterm L l) (ts : dvector (term L) l) (n : ℕ) :
   (apps t ts) ↑ n = apps (t ↑ n) (ts.map $ λx, x ↑ n) :=
 lift_term_at_apps t ts n 0
 
@@ -361,15 +361,15 @@ by simp [subst_term]
 
 lemma subst_term_var0 (s : term L) : &0[s // 0] = s := by simp
 
-@[simp] lemma subst_term_func {l} (f : L.functions l) (s : term L) (n : ℕ) : 
+@[simp] lemma subst_term_func {l} (f : L.functions l) (s : term L) (n : ℕ) :
   (func f)[s // n] = func f :=
 by refl
 
-@[simp] lemma subst_term_app {l} (t₁ : preterm L (l+1)) (t₂ s : term L) (n : ℕ) : 
+@[simp] lemma subst_term_app {l} (t₁ : preterm L (l+1)) (t₂ s : term L) (n : ℕ) :
   (app t₁ t₂)[s // n] = app (t₁[s // n]) (t₂[s // n]) :=
 by refl
 
-@[simp] lemma subst_term_apps {l} (t : preterm L l) (ts : dvector (term L) l) (s : term L) 
+@[simp] lemma subst_term_apps {l} (t : preterm L l) (ts : dvector (term L) l) (s : term L)
   (n : ℕ) : (apps t ts)[s // n] = apps (t[s // n]) (ts.map $ λx, x[s // n]) :=
 by induction ts generalizing t;[refl, apply ts_ih (app t ts_x)]
 
@@ -400,12 +400,12 @@ lemma lift_subst_term_large' {l} (t : preterm L l) (s : term L) (n₁ n₂) :
   (t ↑ n₂)[s // n₂+n₁] = (t [s // n₁]) ↑ n₂ :=
 by rw [add_comm]; apply lift_subst_term_large
 
-lemma lift_at_subst_term_medium : ∀{l} (t : preterm L l) (s : term L) {n₁ n₂ m}, m ≤ n₂ → 
+lemma lift_at_subst_term_medium : ∀{l} (t : preterm L l) (s : term L) {n₁ n₂ m}, m ≤ n₂ →
   n₂ ≤ m + n₁ → (t ↑' n₁+1 # m)[s // n₂] = t ↑' n₁ # m
-| _ &k          s n₁ n₂ m h₁ h₂ := 
-  begin 
+| _ &k          s n₁ n₂ m h₁ h₂ :=
+  begin
     by_cases h : m ≤ k,
-    { have h₃ : n₂ < k + (n₁ + 1), from lt_succ_of_le (le_trans h₂ (add_le_add_right h _)), 
+    { have h₃ : n₂ < k + (n₁ + 1), from lt_succ_of_le (le_trans h₂ (add_le_add_right h _)),
       simp [*, add_sub_cancel_right] },
     { have h₃ : k < n₂, from lt_of_lt_of_le (lt_of_not_ge h) h₁, simp* }
   end
@@ -422,25 +422,25 @@ begin rw [lift_at_subst_term_medium t s, lift_term_at_zero]; refl end
 @[simp] lemma lift_term1_subst_term {l} (t : preterm L l) (s : term L) : (t ↑ 1)[s // 0] = t :=
 lift_at_subst_term_eq t s 0
 
-lemma lift_at_subst_term_small : ∀{l} (t : preterm L l) (s : term L) (n₁ n₂ m), 
+lemma lift_at_subst_term_small : ∀{l} (t : preterm L l) (s : term L) (n₁ n₂ m),
  (t ↑' n₁ # (m + n₂ + 1))[s ↑' n₁ # m // n₂] = (t [s // n₂]) ↑' n₁ # (m + n₂)
-| _ &k          s n₁ n₂ m := 
+| _ &k          s n₁ n₂ m :=
   begin
     by_cases h : m + n₂ + 1 ≤ k,
-    { change m + n₂ + 1 ≤ k at h, 
+    { change m + n₂ + 1 ≤ k at h,
       have h₂ : n₂ < k := lt_of_le_of_lt (le_add_left n₂ m) (lt_of_succ_le h),
-      have h₃ : n₂ < k + n₁ := by apply nat.lt_add_right; exact h₂, 
-      have h₄ : m + n₂ ≤ k - 1 := nat.le_sub_right_of_add_le h, 
+      have h₃ : n₂ < k + n₁ := by apply nat.lt_add_right; exact h₂,
+      have h₄ : m + n₂ ≤ k - 1 := nat.le_sub_right_of_add_le h,
       simp [*, -add_comm, -add_assoc, nat.add_sub_swap (one_le_of_lt h₂)] },
-    { change ¬(m + n₂ + 1 ≤ k) at h, 
+    { change ¬(m + n₂ + 1 ≤ k) at h,
       apply lt_by_cases k n₂; intro h₂,
       { have h₃ : ¬(m + n₂ ≤ k) := λh', not_le_of_gt h₂ (le_trans (le_add_left n₂ m) h'),
         simp [h, h₂, h₃, -add_comm, -add_assoc] },
-      { subst h₂, 
+      { subst h₂,
         have h₃ : ¬(k + m + 1 ≤ k) := by rw [add_comm k m]; exact h,
-        simp [h, h₃, -add_comm, -add_assoc], 
+        simp [h, h₃, -add_comm, -add_assoc],
         exact lift_term_at2_small _ _ _ m.zero_le },
-      { have h₃ : ¬(m + n₂ ≤ k - 1) := 
+      { have h₃ : ¬(m + n₂ ≤ k - 1) :=
           λh', h $ (nat.le_sub_right_iff_add_le $ one_le_of_lt h₂).mp h',
         simp [h, h₂, h₃, -add_comm, -add_assoc] }}
   end
@@ -458,10 +458,10 @@ lemma subst_term2 : ∀{l} (t : preterm L l) (s₁ s₂ : term L) (n₁ n₂),
     { have : k < k + (n₂ + 1), from lt_succ_of_le (le_add_right _ n₂),
       subst h, simp [*, lift_subst_term_large', -add_comm] },
     apply lt_by_cases k (n₁ + n₂ + 1); intro h',
-    { have : k - 1 < n₁ + n₂, from (nat.sub_lt_right_iff_lt_add (one_le_of_lt h)).2 h', 
+    { have : k - 1 < n₁ + n₂, from (nat.sub_lt_right_iff_lt_add (one_le_of_lt h)).2 h',
       simp [*, -add_comm, -add_assoc] },
     { subst h', simp [h, lift_subst_term_medium, -add_comm, -add_assoc] },
-    { have : n₁ + n₂ < k - 1, from nat.lt_sub_right_of_add_lt h', 
+    { have : n₁ + n₂ < k - 1, from nat.lt_sub_right_of_add_lt h',
       have : n₁ < k - 1, from lt_of_le_of_lt (n₁.le_add_right n₂) this,
       simp only [*, eq_self_iff_true, fol.subst_term_var_gt] }
   end
@@ -475,8 +475,8 @@ let h := subst_term2 t s₁ s₂ 0 n in by simp only [zero_add] at h; exact h
 lemma lift_subst_term_cancel : ∀{l} (t : preterm L l) (n : ℕ), (t ↑' 1 # (n+1))[&0 // n] = t
 | _ &k          n :=
   begin
-    apply lt_by_cases n k; intro h, 
-    { change n+1 ≤ k at h, have h' : n < k+1, from lt.step (lt_of_succ_le h), simp [h, h'] }, 
+    apply lt_by_cases n k; intro h,
+    { change n+1 ≤ k at h, have h' : n < k+1, from lt.step (lt_of_succ_le h), simp [h, h'] },
     { have h' : ¬(k+1 ≤ k), from not_succ_le_self k, simp [h, h'] },
     { have h' : ¬(n+1 ≤ k) := not_le_of_lt (lt.step h), simp [h, h'] }
   end
@@ -487,16 +487,16 @@ lemma lift_subst_term_cancel : ∀{l} (t : preterm L l) (n : ℕ), (t ↑' 1 # (
 /- Probably useful facts about substitution which we should add when needed:
 (forall M N i j k, ( M [ j ← N] ) ↑' k # (j+i) = (M ↑' k # (S (j+i))) [ j ← (N ↑' k # i ) ])
 subst_travers : (forall M N P n, (M [← N]) [n ← P] = (M [n+1 ← P])[← N[n← P]])
-erasure_lem3 : (forall n m t, m>n->#m = (#m ↑' 1 # (S n)) [n ← t]). 
-lift_is_lift_sublemma : forall j v, j<v->exists w,#v=w↑1#j. 
+erasure_lem3 : (forall n m t, m>n->#m = (#m ↑' 1 # (S n)) [n ← t]).
+lift_is_lift_sublemma : forall j v, j<v->exists w,#v=w↑1#j.
 lift_is_lift : (forall N A n i j,N ↑' i # n=A ↑' 1 # j -> j<n -> exists M,N=M ↑' 1 # j)
 subst_is_lift : (forall N T A n j, N [n ← T]=A↑' 1#j->j<n->exists M,N=M↑' 1#j)
 -/
 
-/- preformula l is a partially applied formula. if applied to n terms, it becomes a formula. 
+/- preformula l is a partially applied formula. if applied to n terms, it becomes a formula.
   * We only have implication as binary connective. Since we use classical logic, we can define
-    the other connectives from implication and falsum. 
-  * Similarly, universal quantification is our only quantifier. 
+    the other connectives from implication and falsum.
+  * Similarly, universal quantification is our only quantifier.
   * We could make `falsum` and `equal` into elements of rel. However, if we do that, then we cannot make the interpretation of them in a model definitionally what we want.
 -/
 variable (L)
@@ -534,20 +534,20 @@ prefix `∃'`:110 := fol.ex -- input \ex
 @[simp] lemma apps_rel_zero (f : formula L) (ts : dvector (term L) 0) : apps_rel f ts = f :=
 by cases ts; refl
 
--- lemma apps_rel_ne_falsum {l} {R : L.relations l} {ts : dvector (term L) l} : 
+-- lemma apps_rel_ne_falsum {l} {R : L.relations l} {ts : dvector (term L) l} :
 --   apps_rel (rel R) ts ≠ ⊥ :=
 -- by induction l; cases ts; [{cases ts_xs, intro h, injection h}, apply l_ih]
 
--- lemma apps_rel_ne_falsum {l} {f : preformula L (l+1)} {ts : dvector (term L) (l+1)} : 
+-- lemma apps_rel_ne_falsum {l} {f : preformula L (l+1)} {ts : dvector (term L) (l+1)} :
 --   apps_rel f ts ≠ ⊥ :=
 -- by induction l; cases ts; [{cases ts_xs, intro h, injection h}, apply l_ih]
--- lemma apps_rel_ne_equal {l} {f : preformula L (l+1)} {ts : dvector (term L) (l+1)} 
+-- lemma apps_rel_ne_equal {l} {f : preformula L (l+1)} {ts : dvector (term L) (l+1)}
 --   {t₁ t₂ : term L} : apps_rel f ts ≠ t₁ ≃ t₂ :=
 -- by induction l; cases ts; [{cases ts_xs, intro h, injection h}, apply l_ih]
--- lemma apps_rel_ne_imp {l} {f : preformula L (l+1)} {ts : dvector (term L) (l+1)} 
+-- lemma apps_rel_ne_imp {l} {f : preformula L (l+1)} {ts : dvector (term L) (l+1)}
 --   {f₁ f₂ : formula L} : apps_rel f ts ≠ f₁ ⟹ f₂ :=
 -- by induction l; cases ts; [{cases ts_xs, intro h, injection h}, apply l_ih]
--- lemma apps_rel_ne_all {l} {f : preformula L (l+1)} {ts : dvector (term L) (l+1)} 
+-- lemma apps_rel_ne_all {l} {f : preformula L (l+1)} {ts : dvector (term L) (l+1)}
 --   {f' : formula L} : apps_rel f ts ≠ ∀' f' :=
 -- by induction l; cases ts; [{cases ts_xs, intro h, injection h}, apply l_ih]
 
@@ -559,7 +559,7 @@ arity'.of_dvector_map $ apps_rel (rel R)
   (hequal : Π (t₁ t₂ : term L), C (t₁ ≃ t₂))
   (hrel : Π {{l}} (R : L.relations l) (ts : dvector (term L) l), C (apps_rel (rel R) ts))
   (himp : Π {{f₁ f₂ : formula L}} (ih₁ : C f₁) (ih₂ : C f₂), C (f₁ ⟹ f₂))
-  (hall : Π {{f : formula L}} (ih : C f), C (∀' f)) : 
+  (hall : Π {{f : formula L}} (ih : C f), C (∀' f)) :
   ∀{l} (f : preformula L l) (ts : dvector (term L) l), C (apps_rel f ts)
 | _ falsum       ts := by cases ts; exact hfalsum
 | _ (t₁ ≃ t₂)    ts := by cases ts; apply hequal
@@ -581,9 +581,9 @@ arity'.of_dvector_map $ apps_rel (rel R)
   (hequal : Π (t₁ t₂ : term L), C (t₁ ≃ t₂))
   (hrel : Π {{l}} (R : L.relations l) (ts : dvector (term L) l), C (apps_rel (rel R) ts))
   (himp : Π {{f₁ f₂ : formula L}} (ih₁ : C f₁) (ih₂ : C f₂), C (f₁ ⟹ f₂))
-  (hall : Π {{f : formula L}} (ih : C f), C (∀' f)) 
+  (hall : Π {{f : formula L}} (ih : C f), C (∀' f))
   {l} (f : preformula L l) (ts : dvector (term L) l) :
-  @formula.rec' L C hfalsum hequal hrel himp hall 0 (apps_rel f ts) ([]) = 
+  @formula.rec' L C hfalsum hequal hrel himp hall 0 (apps_rel f ts) ([]) =
   @formula.rec' L C hfalsum hequal hrel himp hall l f ts :=
 begin
   induction ts,
@@ -596,8 +596,8 @@ end
   (hequal : Π (t₁ t₂ : term L), C (t₁ ≃ t₂))
   (hrel : Π {{l}} (R : L.relations l) (ts : dvector (term L) l), C (apps_rel (rel R) ts))
   (himp : Π {{f₁ f₂ : formula L}} (ih₁ : C f₁) (ih₂ : C f₂), C (f₁ ⟹ f₂))
-  (hall : Π {{f : formula L}} (ih : C f), C (∀' f)) 
-  {l} (R : L.relations l) (ts : dvector (term L) l) : 
+  (hall : Π {{f : formula L}} (ih : C f), C (∀' f))
+  {l} (R : L.relations l) (ts : dvector (term L) l) :
   @formula.rec L C hfalsum hequal hrel himp hall (apps_rel (rel R) ts) = hrel R ts :=
 by dsimp only [formula.rec]; rw formula.rec'_apps_rel; refl
 
@@ -618,7 +618,7 @@ infix ` ↑ `:100 := fol.lift_formula -- input ↑' with \upa
 @[simp] lemma lift_formula_def {l} (f : preformula L l) (n : ℕ) : f ↑' n # 0 = f ↑ n := by refl
 @[simp] lemma lift_formula1_not (n : ℕ) (f : formula L) : ∼f ↑ n  = ∼(f ↑ n) := by refl
 
-lemma injective_lift_formula_at {l} {n m : ℕ} : 
+lemma injective_lift_formula_at {l} {n m : ℕ} :
   function.injective (λ (f : preformula L l), lift_formula_at f n m) :=
 begin
   intros f f' H, induction f generalizing m; cases f'; injection H,
@@ -637,18 +637,18 @@ end
 | _ (∀' f)       m := by simp; apply lift_formula_at_zero
 
 /- the following lemmas simplify iterated lifts, depending on the size of m' -/
-lemma lift_formula_at2_small : ∀ {l} (f : preformula L l) (n n') {m m'}, m' ≤ m → 
+lemma lift_formula_at2_small : ∀ {l} (f : preformula L l) (n n') {m m'}, m' ≤ m →
   (f ↑' n # m) ↑' n' # m' = (f ↑' n' # m') ↑' n # (m + n')
 | _ falsum       n n' m m' H := by refl
 | _ (t₁ ≃ t₂)    n n' m m' H := by simp [lift_term_at2_small, H]
 | _ (rel R)      n n' m m' H := by refl
-| _ (apprel f t) n n' m m' H := 
+| _ (apprel f t) n n' m m' H :=
   by simp [lift_term_at2_small, H, -add_comm]; apply lift_formula_at2_small; assumption
 | _ (f₁ ⟹ f₂)   n n' m m' H := by dsimp; congr1; apply lift_formula_at2_small; assumption
 | _ (∀' f)       n n' m m' H :=
   by simp [lift_term_at2_small, H, lift_formula_at2_small f n n' (add_le_add_right H 1)]
 
-lemma lift_formula_at2_medium : ∀ {l} (f : preformula L l) (n n') {m m'}, m ≤ m' → m' ≤ m+n → 
+lemma lift_formula_at2_medium : ∀ {l} (f : preformula L l) (n n') {m m'}, m ≤ m' → m' ≤ m+n →
   (f ↑' n # m) ↑' n' # m' = f ↑' (n+n') # m
 | _ falsum       n n' m m' H₁ H₂ := by refl
 | _ (t₁ ≃ t₂)    n n' m m' H₁ H₂ := by simp [*, lift_term_at2_medium]
@@ -658,21 +658,21 @@ lemma lift_formula_at2_medium : ∀ {l} (f : preformula L l) (n n') {m m'}, m �
 | _ (∀' f)       n n' m m' H₁ H₂ :=
   have m' + 1 ≤ (m + 1) + n, from le_trans (add_le_add_right H₂ 1) (by simp), by simp*
 
-lemma lift_formula_at2_eq {l} (f : preformula L l) (n n' m : ℕ) : 
+lemma lift_formula_at2_eq {l} (f : preformula L l) (n n' m : ℕ) :
   (f ↑' n # m) ↑' n' # (m+n) = f ↑' (n+n') # m :=
 lift_formula_at2_medium f n n' (m.le_add_right n) (le_refl _)
 
-lemma lift_formula_at2_large {l} (f : preformula L l) (n n') {m m'} (H : m + n ≤ m') : 
+lemma lift_formula_at2_large {l} (f : preformula L l) (n n') {m m'} (H : m + n ≤ m') :
   (f ↑' n # m) ↑' n' # m' = (f ↑' n' # (m'-n)) ↑' n # m :=
 have H₁ : n ≤ m', from le_trans (n.le_add_left m) H,
 have H₂ : m ≤ m' - n, from nat.le_sub_right_of_add_le H,
 begin rw lift_formula_at2_small f n' n H₂, rw [nat.sub_add_cancel], exact H₁ end
 
-@[simp] lemma lift_formula_at_apps_rel {l} (f : preformula L l) (ts : dvector (term L) l) 
+@[simp] lemma lift_formula_at_apps_rel {l} (f : preformula L l) (ts : dvector (term L) l)
   (n m : ℕ) : (apps_rel f ts) ↑' n # m = apps_rel (f ↑' n # m) (ts.map $ λx, x ↑' n # m) :=
 by induction ts generalizing f;[refl, apply ts_ih (apprel f ts_x)]
 
-@[simp] lemma lift_formula_apps_rel {l} (f : preformula L l) (ts : dvector (term L) l) 
+@[simp] lemma lift_formula_apps_rel {l} (f : preformula L l) (ts : dvector (term L) l)
   (n : ℕ) : (apps_rel f ts) ↑ n = apps_rel (f ↑ n) (ts.map $ λx, x ↑ n) :=
 lift_formula_at_apps_rel f ts n 0
 
@@ -701,7 +701,7 @@ lemma lift_at_subst_formula_large : ∀{l} (f : preformula L l) (s : term L) {n�
 | _ (rel R)      s n₁ n₂ m h := by refl
 | _ (apprel f t) s n₁ n₂ m h := by simp [*, lift_at_subst_term_large]
 | _ (f₁ ⟹ f₂)   s n₁ n₂ m h := by simp*
-| _ (∀' f)       s n₁ n₂ m h := 
+| _ (∀' f)       s n₁ n₂ m h :=
   by have := lift_at_subst_formula_large f s n₂ (add_le_add_right h 1); simp at this; simp*
 
 lemma lift_subst_formula_large {l} (f : preformula L l) (s : term L) {n₁ n₂} :
@@ -712,17 +712,17 @@ lemma lift_subst_formula_large' {l} (f : preformula L l) (s : term L) {n₁ n₂
   (f ↑ n₂)[s // n₂+n₁] = (f [s // n₁]) ↑ n₂ :=
 by rw [add_comm]; apply lift_subst_formula_large
 
-lemma lift_at_subst_formula_medium : ∀{l} (f : preformula L l) (s : term L) {n₁ n₂ m}, m ≤ n₂ → 
+lemma lift_at_subst_formula_medium : ∀{l} (f : preformula L l) (s : term L) {n₁ n₂ m}, m ≤ n₂ →
   n₂ ≤ m + n₁ → (f ↑' n₁+1 # m)[s // n₂] = f ↑' n₁ # m
 | _ falsum       s n₁ n₂ m h₁ h₂ := by refl
 | _ (t₁ ≃ t₂)    s n₁ n₂ m h₁ h₂ := by simp [*, lift_at_subst_term_medium]
 | _ (rel R)      s n₁ n₂ m h₁ h₂ := by refl
 | _ (apprel f t) s n₁ n₂ m h₁ h₂ := by simp [*, lift_at_subst_term_medium]
 | _ (f₁ ⟹ f₂)   s n₁ n₂ m h₁ h₂ := by simp*
-| _ (∀' f)       s n₁ n₂ m h₁ h₂ := 
+| _ (∀' f)       s n₁ n₂ m h₁ h₂ :=
   begin
     have h : n₂ + 1 ≤ (m + 1) + n₁, from le_trans (add_le_add_right h₂ 1) (by simp),
-    have := lift_at_subst_formula_medium f s (add_le_add_right h₁ 1) h, 
+    have := lift_at_subst_formula_medium f s (add_le_add_right h₁ 1) h,
     simp only [fol.subst_formula, fol.lift_formula_at] at this, simp*
   end
 
@@ -730,24 +730,24 @@ lemma lift_subst_formula_medium {l} (f : preformula L l) (s : term L) (n₁ n₂
   (f ↑ ((n₁ + n₂) + 1))[s // n₁] = f ↑ (n₁ + n₂) :=
 lift_at_subst_formula_medium f s n₁.zero_le (by rw [zero_add]; exact n₁.le_add_right n₂)
 
-lemma lift_at_subst_formula_eq {l} (f : preformula L l) (s : term L) (n : ℕ) : 
+lemma lift_at_subst_formula_eq {l} (f : preformula L l) (s : term L) (n : ℕ) :
   (f ↑' 1 # n)[s // n] = f :=
 begin rw [lift_at_subst_formula_medium f s, lift_formula_at_zero]; refl end
 
 @[simp] lemma lift_formula1_subst {l} (f : preformula L l) (s : term L) : (f ↑ 1)[s // 0] = f :=
 lift_at_subst_formula_eq f s 0
 
-lemma lift_at_subst_formula_small : ∀{l} (f : preformula L l) (s : term L) (n₁ n₂ m), 
+lemma lift_at_subst_formula_small : ∀{l} (f : preformula L l) (s : term L) (n₁ n₂ m),
  (f ↑' n₁ # (m + n₂ + 1))[s ↑' n₁ # m // n₂] = (f [s // n₂]) ↑' n₁ # (m + n₂)
 | _ falsum       s n₁ n₂ m := by refl
-| _ (t₁ ≃ t₂)    s n₁ n₂ m := 
+| _ (t₁ ≃ t₂)    s n₁ n₂ m :=
     by dsimp; simp only [lift_at_subst_term_small, eq_self_iff_true, and_self]
 | _ (rel R)      s n₁ n₂ m := by refl
-| _ (apprel f t) s n₁ n₂ m := 
+| _ (apprel f t) s n₁ n₂ m :=
     by dsimp; simp only [*, lift_at_subst_term_small, eq_self_iff_true, and_self]
-| _ (f₁ ⟹ f₂)   s n₁ n₂ m := 
+| _ (f₁ ⟹ f₂)   s n₁ n₂ m :=
     by dsimp; simp only [*, lift_at_subst_term_small, eq_self_iff_true, and_self]
-| _ (∀' f)       s n₁ n₂ m := 
+| _ (∀' f)       s n₁ n₂ m :=
     by have := lift_at_subst_formula_small f s n₁ (n₂+1) m; dsimp; simp at this ⊢; exact this
 
 lemma lift_at_subst_formula_small0 {l} (f : preformula L l) (s : term L) (n₁ m) :
@@ -761,7 +761,7 @@ lemma subst_formula2 : ∀{l} (f : preformula L l) (s₁ s₂ : term L) (n₁ n�
 | _ (rel R)      s₁ s₂ n₁ n₂ := by refl
 | _ (apprel f t) s₁ s₂ n₁ n₂ := by simp [*, subst_term2]
 | _ (f₁ ⟹ f₂)   s₁ s₂ n₁ n₂ := by simp*
-| _ (∀' f)       s₁ s₂ n₁ n₂ := 
+| _ (∀' f)       s₁ s₂ n₁ n₂ :=
   by simp*; rw [add_comm n₂ 1, ←add_assoc, subst_formula2 f s₁ s₂ (n₁ + 1) n₂]; simp
 
 lemma subst_formula2_zero {l} (f : preformula L l) (s₁ s₂ : term L) (n) :
@@ -776,7 +776,7 @@ lemma lift_subst_formula_cancel : ∀{l} (f : preformula L l) (n : ℕ), (f ↑'
 | _ (f₁ ⟹ f₂)   n := by simp*
 | _ (∀' f)       n := by simp*
 
-@[simp] lemma subst_formula_apps_rel {l} (f : preformula L l) (ts : dvector (term L) l) (s : term L) 
+@[simp] lemma subst_formula_apps_rel {l} (f : preformula L l) (ts : dvector (term L) l) (s : term L)
   (n : ℕ): (apps_rel f ts)[s // n] = apps_rel (f[s // n]) (ts.map $ λx, x[s // n]) :=
 by induction ts generalizing f;[refl, apply ts_ih (apprel f ts_x)]
 
@@ -826,12 +826,12 @@ infix ` ⊢' `:51 := fol.provable -- input: \|- or \vdash
 def allE {Γ} (A : formula L) (t) {B} (H₁ : Γ ⊢ ∀' A) (H₂ : A[t // 0] = B) : Γ ⊢ B :=
 by induction H₂; exact allE₂ A t H₁
 
-def subst {Γ} {s t} (f₁ : formula L) {f₂} (H₁ : Γ ⊢ s ≃ t) (H₂ : Γ ⊢ f₁[s // 0]) 
+def subst {Γ} {s t} (f₁ : formula L) {f₂} (H₁ : Γ ⊢ s ≃ t) (H₂ : Γ ⊢ f₁[s // 0])
   (H₃ : f₁[t // 0] = f₂) : Γ ⊢ f₂ :=
 by induction H₃; exact subst₂ s t f₁ H₁ H₂
 
 def axm1 {Γ : set (formula L)} {A : formula L} : insert A Γ ⊢ A := by apply axm; left; refl
-def axm2 {Γ : set (formula L)} {A B : formula L} : insert A (insert B Γ) ⊢ B := 
+def axm2 {Γ : set (formula L)} {A B : formula L} : insert A (insert B Γ) ⊢ B :=
 by apply axm; right; left; refl
 
 def weakening {Γ Δ} {f : formula L} (H₁ : Γ ⊆ Δ) (H₂ : Γ ⊢ f) : Δ ⊢ f :=
@@ -854,12 +854,12 @@ begin
   { apply impI, have h := @H_ih m, rw [image_insert_eq] at h, exact h },
   { apply impE, apply H_ih_h₁, apply H_ih_h₂ },
   { apply falsumE, have h := @H_ih m, rw [image_insert_eq] at h, exact h },
-  { apply allI, rw [image_image], have h := @H_ih (m+1), rw [image_image] at h, 
+  { apply allI, rw [image_image], have h := @H_ih (m+1), rw [image_image] at h,
     apply cast _ h, congr1, apply image_congr', intro f', symmetry,
     exact lift_formula_at2_small f' _ _ m.zero_le },
   { apply allE _ _ (H_ih m), apply lift_at_subst_formula_small0 },
   { apply ref },
-  { apply subst _ (H_ih_h₁ m), 
+  { apply subst _ (H_ih_h₁ m),
     { have h := @H_ih_h₂ m, rw [←lift_at_subst_formula_small0] at h, exact h},
     rw [lift_at_subst_formula_small0] },
 end
@@ -871,12 +871,12 @@ begin
   { apply impI, have h := H_ih n, rw [image_insert_eq] at h, exact h },
   { apply impE, apply H_ih_h₁, apply H_ih_h₂ },
   { apply falsumE, have h := H_ih n, rw [image_insert_eq] at h, exact h },
-  { apply allI, rw [image_image], have h := @H_ih (n+1), rw [image_image] at h, 
+  { apply allI, rw [image_image], have h := @H_ih (n+1), rw [image_image] at h,
     apply cast _ h, congr1, apply image_congr', intro,
     apply lift_subst_formula_large },
   { apply allE _ _ (H_ih n), symmetry, apply subst_formula2_zero },
   { apply ref },
-  { apply subst _ (H_ih_h₁ n), { have h := @H_ih_h₂ n, rw [subst_formula2_zero] at h, exact h}, 
+  { apply subst _ (H_ih_h₁ n), { have h := @H_ih_h₂ n, rw [subst_formula2_zero] at h, exact h},
     rw [subst_formula2_zero] },
 end
 
@@ -914,14 +914,14 @@ def notI {Γ} {A : formula L} (H : Γ ⊢ A ⟹ falsum) : Γ ⊢ ∼ A :=
   by {rw[not], assumption}
 
 def andI {Γ} {f₁ f₂ : formula L} (H₁ : Γ ⊢ f₁) (H₂ : Γ ⊢ f₂) : Γ ⊢ f₁ ⊓ f₂ :=
-begin 
+begin
   apply impI, apply impE f₂,
   { apply impE f₁, apply axm1, exact weakening1 H₁ },
   { exact weakening1 H₂ }
 end
 
 def andE1 {Γ f₁} (f₂ : formula L) (H : Γ ⊢ f₁ ⊓ f₂) : Γ ⊢ f₁ :=
-begin 
+begin
   apply falsumE, apply impE _ (weakening1 H), apply impI, apply exfalso,
   apply impE f₁; [apply axm2, apply axm1]
 end
@@ -935,7 +935,7 @@ begin apply impI, apply exfalso, refine impE _ _ (weakening1 H), apply axm1 end
 def orI2 {Γ} {A B : formula L} (H : Γ ⊢ B) : Γ ⊢ A ⊔ B :=
 impI $ weakening1 H
 
-def orE {Γ} {A B C : formula L} (H₁ : Γ ⊢ A ⊔ B) (H₂ : insert A Γ ⊢ C) (H₃ : insert B Γ ⊢ C) : 
+def orE {Γ} {A B C : formula L} (H₁ : Γ ⊢ A ⊔ B) (H₂ : insert A Γ ⊢ C) (H₃ : insert B Γ ⊢ C) :
   Γ ⊢ C :=
 begin
   apply falsumE, apply impE C, { apply axm1 },
@@ -952,15 +952,15 @@ def biimpE2 {Γ} {f₁ f₂ : formula L} (H : Γ ⊢ f₁ ⇔ f₂) : insert f�
 
 def exI {Γ f} (t : term L) (H : Γ ⊢ f [t // 0]) : Γ ⊢ ∃' f :=
 begin
-  apply impI, 
+  apply impI,
   apply impE (f[t // 0]) _ (weakening1 H),
   apply allE₂ ∼f t axm1,
 end
 
-def exE {Γ} {f₁ f₂ : formula L} (H₁ : Γ ⊢ ∃' f₁) 
+def exE {Γ} {f₁ f₂ : formula L} (H₁ : Γ ⊢ ∃' f₁)
   (H₂ : insert f₁ (lift_formula1 '' Γ) ⊢ lift_formula1 f₂) : Γ ⊢ f₂ :=
 begin
-  apply falsumE, apply impE _ (weakening1 H₁), apply allI, apply impI, 
+  apply falsumE, apply impE _ (weakening1 H₁), apply allI, apply impI,
   rw [image_insert_eq], apply impE _ axm2, apply weakening2 H₂
 end
 
@@ -976,32 +976,32 @@ impE f (andE2 f H) (andE1 ∼f H)
 
 -- def andE1 {Γ f₁} (f₂ : formula L) (H : Γ ⊢ f₁ ⊓ f₂) : Γ ⊢ f₁ :=
 def symm {Γ} {s t : term L} (H : Γ ⊢ s ≃ t) : Γ ⊢ t ≃ s :=
-begin 
+begin
   apply subst (&0 ≃ s ↑ 1) H; rw [subst_formula_equal, lift_term1_subst_term, subst_term_var0],
   apply ref
 end
 
 def trans {Γ} {t₁ t₂ t₃ : term L} (H : Γ ⊢ t₁ ≃ t₂) (H' : Γ ⊢ t₂ ≃ t₃) : Γ ⊢ t₁ ≃ t₃ :=
-begin 
+begin
   apply subst (t₁ ↑ 1 ≃ &0) H'; rw [subst_formula_equal, lift_term1_subst_term, subst_term_var0],
   exact H
 end
 
 def congr {Γ} {t₁ t₂ : term L} (s : term L) (H : Γ ⊢ t₁ ≃ t₂) : Γ ⊢ s[t₁ // 0] ≃ s[t₂ // 0] :=
-begin 
-  apply subst (s[t₁ // 0] ↑ 1 ≃ s) H, 
+begin
+  apply subst (s[t₁ // 0] ↑ 1 ≃ s) H,
   { rw [subst_formula_equal, lift_term1_subst_term], apply ref },
   { rw [subst_formula_equal, lift_term1_subst_term] }
 end
 
 def app_congr {Γ} {t₁ t₂ : term L} (s : preterm L 1) (H : Γ ⊢ t₁ ≃ t₂) : Γ ⊢ app s t₁ ≃ app s t₂ :=
-begin 
+begin
   have h := congr (app (s ↑ 1) &0) H, simp at h, exact h
 end
 
 def apprel_congr {Γ} {t₁ t₂ : term L} (f : preformula L 1) (H : Γ ⊢ t₁ ≃ t₂)
   (H₂ : Γ ⊢ apprel f t₁) : Γ ⊢ apprel f t₂ :=
-begin 
+begin
   apply subst (apprel (f ↑ 1) &0) H; simp, exact H₂
 end
 
@@ -1015,19 +1015,19 @@ by apply biimpI; apply axm1
 
 def biimp_trans {Γ} {f₁ f₂ f₃ : formula L} (H₁ : Γ ⊢ f₁ ⇔ f₂) (H₂ : Γ ⊢ f₂ ⇔ f₃) : Γ ⊢ f₁ ⇔ f₃ :=
 begin
-  apply andI; apply imp_trans, 
+  apply andI; apply imp_trans,
   apply andE1 _ H₁, apply andE1 _ H₂, apply andE2 _ H₂, apply andE2 _ H₁
 end
 
 def equal_preterms (T : set (formula L)) {l} (t₁ t₂ : preterm L l) : Type u :=
 ∀(ts : dvector (term L) l), T ⊢ apps t₁ ts ≃ apps t₂ ts
 
-def equal_preterms_app {T : set (formula L)} {l} {t t' : preterm L (l+1)} {s s' : term L} 
+def equal_preterms_app {T : set (formula L)} {l} {t t' : preterm L (l+1)} {s s' : term L}
   (Ht : equal_preterms T t t') (Hs : T ⊢ s ≃ s') : equal_preterms T (app t s) (app t' s') :=
 begin
   intro xs,
   apply trans (Ht (xs.cons s)),
-  have h := congr (apps (t' ↑ 1) (&0 :: xs.map lift_term1)) Hs, 
+  have h := congr (apps (t' ↑ 1) (&0 :: xs.map lift_term1)) Hs,
   simp [dvector.map_congr (λt, lift_term1_subst_term t s')] at h,
   exact h
 end
@@ -1038,19 +1038,19 @@ end
 def equiv_preformulae (T : set (formula L)) {l} (f₁ f₂ : preformula L l) : Type u :=
 ∀(ts : dvector (term L) l), T ⊢ apps_rel f₁ ts ⇔ apps_rel f₂ ts
 
-def equiv_preformulae_apprel {T : set (formula L)} {l} {f f' : preformula L (l+1)} {s s' : term L} 
-  (Ht : equiv_preformulae T f f') (Hs : T ⊢ s ≃ s') : 
+def equiv_preformulae_apprel {T : set (formula L)} {l} {f f' : preformula L (l+1)} {s s' : term L}
+  (Ht : equiv_preformulae T f f') (Hs : T ⊢ s ≃ s') :
     equiv_preformulae T (apprel f s) (apprel f' s') :=
 begin
-  intro xs, 
+  intro xs,
   apply biimp_trans (Ht (xs.cons s)),
-  apply subst (apps_rel (f' ↑ 1) ((s :: xs).map lift_term1) ⇔ 
-               apps_rel (f' ↑ 1) (&0 :: xs.map lift_term1)) Hs; 
+  apply subst (apps_rel (f' ↑ 1) ((s :: xs).map lift_term1) ⇔
+               apps_rel (f' ↑ 1) (&0 :: xs.map lift_term1)) Hs;
     simp [dvector.map_congr (λt, lift_term1_subst_term t s')],
   apply biimp_refl
 end
 
-@[refl] def equiv_preformulae_refl (T : set (formula L)) {l} (f : preformula L l) : 
+@[refl] def equiv_preformulae_refl (T : set (formula L)) {l} (f : preformula L l) :
   equiv_preformulae T f f :=
 λxs, biimp_refl T (apps_rel f xs)
 
@@ -1062,10 +1062,10 @@ def allE' {Γ} (A : formula L) (t) {B} (H₁ : Γ ⊢' ∀' A) (H₂ : A[t // 0]
 H₁.map (λx, allE _ _ x H₂)
 def allE₂' {Γ} {A} {t : term L} (h : Γ ⊢' ∀' A) : Γ ⊢' A[t // 0] := h.map (λx, allE _ _ x rfl)
 def ref' (Γ) (t : term L) : Γ ⊢' (t ≃ t) := ⟨ref Γ t⟩
-def subst' {Γ} {s t} (f₁ : formula L) {f₂} (H₁ : Γ ⊢' s ≃ t) (H₂ : Γ ⊢' f₁[s // 0]) 
-  (H₃ : f₁[t // 0] = f₂) : Γ ⊢' f₂ := 
+def subst' {Γ} {s t} (f₁ : formula L) {f₂} (H₁ : Γ ⊢' s ≃ t) (H₂ : Γ ⊢' f₁[s // 0])
+  (H₃ : f₁[t // 0] = f₂) : Γ ⊢' f₂ :=
 H₁.map2 (λx y, subst _ x y H₃) H₂
-def subst₂' {Γ} (s t) (f : formula L) (h₁ : Γ ⊢' s ≃ t) (h₂ : Γ ⊢' f[s // 0]) : Γ ⊢' f[t // 0] := 
+def subst₂' {Γ} (s t) (f : formula L) (h₁ : Γ ⊢' s ≃ t) (h₂ : Γ ⊢' f[s // 0]) : Γ ⊢' f[t // 0] :=
 h₁.map2 (subst₂ _ _ _) h₂
 
 def weakening' {Γ Δ} {f : formula L} (H₁ : Γ ⊆ Δ) (H₂ : Γ ⊢' f) : Δ ⊢' f := H₂.map $ weakening H₁
@@ -1080,19 +1080,19 @@ lemma apprel_congr' {Γ} {t₁ t₂ : term L} (f : preformula L 1) (H : Γ ⊢ t
 lemma prf_all_iff {Γ : set (formula L)} {f} : Γ ⊢' ∀' f ↔ lift_formula1 '' Γ ⊢' f :=
 begin
   split,
-  { intro H, rw [←lift_subst_formula_cancel f 0], 
+  { intro H, rw [←lift_subst_formula_cancel f 0],
     apply allE₂', apply H.map (prf_lift 1 0) },
   { exact allI' }
 end
 
 lemma iff_of_biimp {Γ} {f₁ f₂ : formula L} (H : Γ ⊢' f₁ ⇔ f₂) : Γ ⊢' f₁ ↔ Γ ⊢' f₂ :=
-⟨impE' _ $ H.map (andE1 _), impE' _ $ H.map (andE2 _)⟩ 
+⟨impE' _ $ H.map (andE1 _), impE' _ $ H.map (andE2 _)⟩
 
 lemma prf_by_cases {Γ} (f₁) {f₂ : formula L} (H₁ : insert f₁ Γ ⊢' f₂)
   (H₂ : insert ∼f₁ Γ ⊢' f₂) : Γ ⊢' f₂ :=
 begin
   apply falsumE', apply impE' _ ⟨axm1⟩,
-  refine impE' _ (impI' (weakening2' H₁)) _, 
+  refine impE' _ (impI' (weakening2' H₁)) _,
   apply falsumE', apply impE' _ ⟨axm2⟩, apply weakening2' H₂
 end
 
@@ -1101,38 +1101,38 @@ end
 /- an L-structure is a type S with interpretations of the functions and relations on S -/
 variable (L)
 structure Structure :=
-(carrier : Type u) 
+(carrier : Type u)
 (fun_map : ∀{n}, L.functions n → dvector carrier n → carrier)
-(rel_map : ∀{n}, L.relations n → dvector carrier n → Prop) 
+(rel_map : ∀{n}, L.relations n → dvector carrier n → Prop)
 variable {L}
 instance has_coe_Structure : has_coe_to_sort (@fol.Structure L) :=
 ⟨Type u, Structure.carrier⟩
 
 /- realization of terms -/
-@[simp] def realize_term {S : Structure L} (v : ℕ → S) : 
+@[simp] def realize_term {S : Structure L} (v : ℕ → S) :
   ∀{l} (t : preterm L l) (xs : dvector S l), S.carrier
 | _ &k          xs := v k
 | _ (func f)    xs := S.fun_map f xs
 | _ (app t₁ t₂) xs := realize_term t₁ $ realize_term t₂ ([])::xs
 
-lemma realize_term_congr {S : Structure L} {v v' : ℕ → S} (h : ∀n, v n = v' n) : 
+lemma realize_term_congr {S : Structure L} {v v' : ℕ → S} (h : ∀n, v n = v' n) :
   ∀{l} (t : preterm L l) (xs : dvector S l), realize_term v t xs = realize_term v' t xs
 | _ &k          xs := h k
 | _ (func f)    xs := by refl
 | _ (app t₁ t₂) xs := by dsimp; rw [realize_term_congr t₁, realize_term_congr t₂]
 
-lemma realize_term_subst {S : Structure L} (v : ℕ → S) : ∀{l} (n : ℕ) (t : preterm L l) 
+lemma realize_term_subst {S : Structure L} (v : ℕ → S) : ∀{l} (n : ℕ) (t : preterm L l)
   (s : term L) (xs : dvector S l), realize_term (v[realize_term v (s ↑ n) ([]) // n]) t xs = realize_term v (t[s // n]) xs
-| _ n &k          s [] := 
+| _ n &k          s [] :=
   by apply lt_by_cases k n; intro h;[simp [h], {subst h; simp}, simp [h]]
 | _ n (func f)    s xs := by refl
 | _ n (app t₁ t₂) s xs := by dsimp; simp*
 
 lemma realize_term_subst_lift {S : Structure L} (v : ℕ → S) (x : S) (m : ℕ) : ∀{l} (t : preterm L l)
   (xs : dvector S l), realize_term (v [x // m]) (t ↑' 1 # m) xs = realize_term v t xs
-| _ &k          [] := 
-  begin 
-    by_cases h : m ≤ k, 
+| _ &k          [] :=
+  begin
+    by_cases h : m ≤ k,
     { have : m < k + 1, from lt_succ_of_le h, simp* },
     { have : k < m, from lt_of_not_ge h, simp* }
   end
@@ -1148,27 +1148,27 @@ lemma realize_term_subst_lift {S : Structure L} (v : ℕ → S) (x : S) (m : ℕ
 | _ v (f₁ ⟹ f₂)   xs := realize_formula v f₁ xs → realize_formula v f₂ xs
 | _ v (∀' f)       xs := ∀(x : S), realize_formula (v [x // 0]) f xs
 
-lemma realize_formula_congr {S : Structure L} : ∀{l} {v v' : ℕ → S} (h : ∀n, v n = v' n) 
+lemma realize_formula_congr {S : Structure L} : ∀{l} {v v' : ℕ → S} (h : ∀n, v n = v' n)
   (f : preformula L l) (xs : dvector S l), realize_formula v f xs ↔ realize_formula v' f xs
 | _ v v' h falsum       xs := by refl
 | _ v v' h (t₁ ≃ t₂)    xs := by simp [realize_term_congr h]
 | _ v v' h (rel R)      xs := by refl
 | _ v v' h (apprel f t) xs := by simp [realize_term_congr h]; rw [realize_formula_congr h]
 | _ v v' h (f₁ ⟹ f₂)   xs := by dsimp; rw [realize_formula_congr h, realize_formula_congr h]
-| _ v v' h (∀' f)       xs := 
-  by apply forall_congr; intro x; apply realize_formula_congr; intro n; 
+| _ v v' h (∀' f)       xs :=
+  by apply forall_congr; intro x; apply realize_formula_congr; intro n;
      apply subst_realize_congr h
 
-lemma realize_formula_subst {S : Structure L} : ∀{l} (v : ℕ → S) (n : ℕ) (f : preformula L l) 
+lemma realize_formula_subst {S : Structure L} : ∀{l} (v : ℕ → S) (n : ℕ) (f : preformula L l)
   (s : term L) (xs : dvector S l), realize_formula (v[realize_term v (s ↑ n) ([]) // n]) f xs ↔ realize_formula v (f[s // n]) xs
 | _ v n falsum       s xs := by refl
 | _ v n (t₁ ≃ t₂)    s xs := by simp [realize_term_subst]
 | _ v n (rel R)      s xs := by refl
 | _ v n (apprel f t) s xs := by simp [realize_term_subst]; rw realize_formula_subst
 | _ v n (f₁ ⟹ f₂)   s xs := by apply imp_congr; apply realize_formula_subst
-| _ v n (∀' f)       s xs := 
-  begin 
-    apply forall_congr, intro x, rw [←realize_formula_subst], apply realize_formula_congr, 
+| _ v n (∀' f)       s xs :=
+  begin
+    apply forall_congr, intro x, rw [←realize_formula_subst], apply realize_formula_congr,
     intro k, rw [subst_realize2_0, ←realize_term_subst_lift v x 0, lift_term_def, lift_term2]
   end
 
@@ -1176,38 +1176,38 @@ lemma realize_formula_subst0 {S : Structure L} {l} (v : ℕ → S) (f : preformu
   realize_formula (v[realize_term v s ([]) // 0]) f xs ↔ realize_formula v (f[s // 0]) xs :=
 by have h := realize_formula_subst v 0 f s; simp at h; exact h xs
 
-lemma realize_formula_subst_lift {S : Structure L} : ∀{l} (v : ℕ → S) (x : S) (m : ℕ) 
+lemma realize_formula_subst_lift {S : Structure L} : ∀{l} (v : ℕ → S) (x : S) (m : ℕ)
   (f : preformula L l) (xs : dvector S l), realize_formula (v [x // m]) (f ↑' 1 # m) xs = realize_formula v f xs
 | _ v x m falsum       xs := by refl
 | _ v x m (t₁ ≃ t₂)    xs := by simp [realize_term_subst_lift]
 | _ v x m (rel R)      xs := by refl
 | _ v x m (apprel f t) xs := by simp [realize_term_subst_lift]; rw realize_formula_subst_lift
 | _ v x m (f₁ ⟹ f₂)   xs := by apply imp_eq_congr; apply realize_formula_subst_lift
-| _ v x m (∀' f)       xs := 
-  begin 
-    apply forall_eq_congr, intro x', 
+| _ v x m (∀' f)       xs :=
+  begin
+    apply forall_eq_congr, intro x',
     rw [realize_formula_congr (subst_realize2_0 _ _ _ _), realize_formula_subst_lift]
   end
 
-/- the following definitions of provability and satisfiability are not exactly how you normally define them, since we define it for formulae instead of sentences. If all the formulae happen to be sentences, then these definitions are equivalent to the normal definitions (the realization of closed terms and sentences are independent of the realizer v). 
+/- the following definitions of provability and satisfiability are not exactly how you normally define them, since we define it for formulae instead of sentences. If all the formulae happen to be sentences, then these definitions are equivalent to the normal definitions (the realization of closed terms and sentences are independent of the realizer v).
  -/
 def all_prf (T T' : set (formula L)) := ∀{{f}}, f ∈ T' → T ⊢ f
 infix ` ⊢ `:51 := fol.all_prf -- input: |- or \vdash
 
 def satisfied_in (S : Structure L) (f : formula L) := ∀(v : ℕ → S), realize_formula v f ([])
-infix ` ⊨ `:51 := fol.satisfied_in -- input using \|= or \vDash, but not using \models 
+infix ` ⊨ `:51 := fol.satisfied_in -- input using \|= or \vDash, but not using \models
 
 def all_satisfied_in (S : Structure L) (T : set (formula L)) := ∀{{f}}, f ∈ T → S ⊨ f
-infix ` ⊨ `:51 := fol.all_satisfied_in -- input using \|= or \vDash, but not using \models 
+infix ` ⊨ `:51 := fol.all_satisfied_in -- input using \|= or \vDash, but not using \models
 
-def satisfied (T : set (formula L)) (f : formula L) := 
-∀(S : Structure L) (v : ℕ → S), (∀f' ∈ T, realize_formula v (f' : formula L) ([])) → 
+def satisfied (T : set (formula L)) (f : formula L) :=
+∀(S : Structure L) (v : ℕ → S), (∀f' ∈ T, realize_formula v (f' : formula L) ([])) →
   realize_formula v f ([])
 
-infix ` ⊨ `:51 := fol.satisfied -- input using \|= or \vDash, but not using \models 
+infix ` ⊨ `:51 := fol.satisfied -- input using \|= or \vDash, but not using \models
 
 def all_satisfied (T T' : set (formula L)) := ∀{{f}}, f ∈ T' → T ⊨ f
-infix ` ⊨ `:51 := fol.all_satisfied -- input using \|= or \vDash, but not using \models 
+infix ` ⊨ `:51 := fol.all_satisfied -- input using \|= or \vDash, but not using \models
 
 def satisfied_in_trans {S : Structure L} {T : set (formula L)} {f : formula L} (H' : S ⊨ T) (H : T ⊨ f) :
   S ⊨ f :=
@@ -1239,9 +1239,9 @@ begin
   { apply h, apply H_h },
   { intro ha, apply H_ih, intros f hf, induction hf, { subst hf, assumption }, apply h f hf },
   { exact H_ih_h₁ v h (H_ih_h₂ v h) },
-  { apply classical.by_contradiction, intro ha, 
+  { apply classical.by_contradiction, intro ha,
     apply H_ih v, intros f hf, induction hf, { cases hf, exact ha }, apply h f hf },
-  { intro x, apply H_ih, intros f hf, cases (mem_image _ _ _).mp hf with f' hf', induction hf', 
+  { intro x, apply H_ih, intros f hf, cases (mem_image _ _ _).mp hf with f' hf', induction hf',
     induction hf'_right, rw [realize_formula_subst_lift v x 0 f'], exact h f' hf'_left },
   { rw [←realize_formula_subst0], apply H_ih v h (realize_term v H_t ([])) },
   { dsimp, refl },
@@ -1250,9 +1250,14 @@ begin
 end
 
 /- sentences and theories -/
+def is_bounded_preterm (n : ℕ) : ∀ {l}, preterm L l → Prop
+| _ (var k) := k < n
+| _ (func f) := true
+| _ (app t s) := is_bounded_preterm t ∧ is_bounded_preterm s
+
 variable (L)
 inductive bounded_preterm (n : ℕ) : ℕ → Type u
-| bd_var {} : ∀ (k : fin n), bounded_preterm 0
+| bd_var {} : ∀ (k : dfin n), bounded_preterm 0
 | bd_func {} : ∀ {l : ℕ} (f : L.functions l), bounded_preterm l
 | bd_app : ∀ {l : ℕ} (t : bounded_preterm (l + 1)) (s : bounded_preterm 0), bounded_preterm l
 export bounded_preterm
@@ -1265,21 +1270,63 @@ variable {L}
 prefix `&`:max := bd_var
 def bd_const {n} (c : L.constants) : bounded_term L n := bd_func c
 
-@[simp] def bd_apps {n} : ∀{l}, bounded_preterm L n l → dvector (bounded_term L n) l → 
+@[simp] def bd_apps {n} : ∀{l}, bounded_preterm L n l → dvector (bounded_term L n) l →
   bounded_term L n
 | _ t []       := t
 | _ t (t'::ts) := bd_apps (bd_app t t') ts
 
+namespace is_bounded_preterm
+
+theorem mono {m n} (mn : m ≤ n) : ∀ {l} {t : preterm L l},
+  is_bounded_preterm m t → is_bounded_preterm n t
+| _ (var k) h := lt_of_lt_of_le h mn
+| _ (func f) h := trivial
+| _ (app t s) h := h.imp mono mono
+
+lemma lift_irrel {n : ℕ} : ∀{l} {t : preterm L l} (ht : is_bounded_preterm n t)
+  (n') {m : ℕ} (h : n ≤ m), t ↑' n' # m = t
+| _ &k           ht n' m h :=
+  have ¬ m ≤ k, by simpa [is_bounded_preterm] using mono h ht,
+  by simp [this]
+| _ (func f)  ht n' m h := by refl
+| _ (app t s) ht n' m h := by simp [lift_irrel ht.1 n' h, lift_irrel ht.2 n' h]
+
+lemma subst_irrel {n : ℕ} : ∀{l} {t : preterm L l} (ht : is_bounded_preterm n t) {n'} (s : term L)
+  (h : n ≤ n'), t[s // n'] = t
+| _ &k          ht n' s h := by simp [lt_of_lt_of_le ht h]
+| _ (func f)    ht n' s h := rfl
+| _ (app t₁ t₂) ht n' s h := by simp [subst_irrel ht.1 s h, subst_irrel ht.2 s h]
+
+end is_bounded_preterm
+
 namespace bounded_preterm
 @[simp] protected def fst {n} : ∀{l}, bounded_preterm L n l → preterm L l
-| _ &k           := &k.1
+| _ &k           := &k.to_nat
 | _ (bd_func f)  := func f
 | _ (bd_app t s) := app (fst t) (fst s)
+
+@[simp]def mk {n : ℕ} : ∀ {l} (t : preterm L l),
+  is_bounded_preterm n t → bounded_preterm L n l
+| _ (var k) h := bd_var (dfin.of_nat_lt k h)
+| _ (func f) h := bd_func f
+| _ (app t s) h := bd_app (mk t h.1) (mk s h.2)
+
+@[simp] theorem fst_mk {n : ℕ} : ∀ {l} {t : preterm L l}
+  (h : is_bounded_preterm n t), (mk t h).fst = t
+| _ (var k) h := by simp
+| _ (func f) h := rfl
+| _ (app t s) h := by simp*
+
+@[simp] theorem fst_bounded {n : ℕ} : ∀ {l} (t : bounded_preterm L n l),
+  is_bounded_preterm n t.fst
+| _ &k           := k.to_nat_lt
+| _ (bd_func f)  := trivial
+| _ (bd_app t s) := ⟨fst_bounded t, fst_bounded s⟩
 
 local attribute [extensionality] fin.eq_of_veq
 @[extensionality] protected def eq {n} : ∀{l} {t₁ t₂ : bounded_preterm L n l} (h : t₁.fst = t₂.fst),
   t₁ = t₂
-| _ &k &k'                        h := by injection h with h'; congr1; ext; exact h'
+| _ &k &k'                        h := by injection h with h'; congr1; exact dfin.to_nat_inj h'
 | _ &k (bd_func f')               h := by injection h
 | _ &k (bd_app t₁' t₂')           h := by injection h
 | _ (bd_func f) &k'               h := by injection h
@@ -1289,7 +1336,10 @@ local attribute [extensionality] fin.eq_of_veq
 | _ (bd_app t₁ t₂) (bd_func f')   h := by injection h
 | _ (bd_app t₁ t₂) (bd_app t₁' t₂') h := by injection h with h₁ h₂; congr1; apply eq; assumption
 
-@[simp] protected def cast {n m} (h : n ≤ m) : ∀ {l} (t : bounded_preterm L n l), 
+theorem mk_fst {n : ℕ} {l} (t : bounded_preterm L n l) : mk t.fst t.fst_bounded = t :=
+by ext; simp
+
+@[simp] protected def cast {n m} (h : n ≤ m) : ∀ {l} (t : bounded_preterm L n l),
   bounded_preterm L m l
 | _ &k           := &(k.cast_le h)
 | _ (bd_func f)  := bd_func f
@@ -1302,29 +1352,25 @@ by {induction ts generalizing t, refl, simp*}
 
 -- @[simp]lemma cast_bd_apps_nil {n m} (h : n ≤ m) {l} {t : bounded_preterm L n (l+1)} {s : bounded_preterm L n 0} : (bd_apps t s []).cast h = (bd_app (t.cast h) (s.cast h))
 
-@[simp] lemma cast_irrel {n m } {h h' : n ≤ m} : ∀ {l} (t : bounded_preterm L n l), (t.cast h) = (t.cast h') :=
-  by {intros, refl}
+@[simp] lemma cast_irrel {n m } {h h' : n ≤ m} {l} (t : bounded_preterm L n l) : t.cast h = t.cast h' := rfl
 
-@[simp] lemma cast_rfl {n} {h : n ≤ n} : ∀ {l} (t : bounded_preterm L n l), (t.cast h) = t :=
-begin
-  intros, induction t,
-  {simp, unfold fin.cast_le, unfold fin.cast_lt, cases t, refl}, {refl}, {simp*}
-end
-  
+@[simp] lemma cast_fst {n m} (h : n ≤ m) : ∀ {l} (t : bounded_preterm L n l), (t.cast h).fst = t.fst
+| _ &k           := by simp
+| _ (bd_func f)  := by refl
+| _ (bd_app t s) := by dsimp; simp [cast_fst]
+
+@[simp] lemma cast_rfl {n} {h : n ≤ n} {l} (t : bounded_preterm L n l) : t.cast h = t :=
+by ext; simp
+
 protected def cast_eq {n m l} (h : n = m) (t : bounded_preterm L n l) : bounded_preterm L m l :=
 t.cast $ le_of_eq h
 
 protected def cast1 {n l} (t : bounded_preterm L n l) : bounded_preterm L (n+1) l :=
 t.cast $ n.le_add_right 1
 
-@[simp] lemma cast_fst {n m} (h : n ≤ m) : ∀ {l} (t : bounded_preterm L n l), (t.cast h).fst = t.fst
-| _ &k           := by refl
-| _ (bd_func f)  := by refl
-| _ (bd_app t s) := by dsimp; simp [cast_fst]
-
-@[simp] lemma cast_eq_fst {n m l} (h : n = m) (t : bounded_preterm L n l) : 
+@[simp] lemma cast_eq_fst {n m l} (h : n = m) (t : bounded_preterm L n l) :
   (t.cast_eq h).fst = t.fst := t.cast_fst _
-@[simp] lemma cast1_fst {n l} (t : bounded_preterm L n l) : 
+@[simp] lemma cast1_fst {n l} (t : bounded_preterm L n l) :
   t.cast1.fst = t.fst := t.cast_fst _
 
 end bounded_preterm
@@ -1334,60 +1380,55 @@ namespace closed_preterm
 protected def cast0 (n) {l} (t : closed_preterm L l) : bounded_preterm L n l :=
 t.cast n.zero_le
 
-@[simp] lemma cast0_fst {n l : ℕ} (t : closed_preterm L l) : 
+@[simp] lemma cast0_fst {n l : ℕ} (t : closed_preterm L l) :
   (t.cast0 n).fst = t.fst :=
 cast_fst _ _
 
 end closed_preterm
 
 @[elab_as_eliminator] def bounded_term.rec {n} {C : bounded_term L n → Sort v}
-  (hvar : ∀(k : fin n), C &k)
-  (hfunc : Π {l} (f : L.functions l) (ts : dvector (bounded_term L n) l) 
-    (ih_ts : ∀t, ts.pmem t → C t), C (bd_apps (bd_func f) ts)) : 
+  (hvar : ∀(k : dfin n), C &k)
+  (hfunc : Π {l} (f : L.functions l) (ts : dvector (bounded_term L n) l)
+    (ih_ts : ∀t, ts.pmem t → C t), C (bd_apps (bd_func f) ts)) :
   ∀(t : bounded_term L n), C t :=
-have h : ∀{l} (t : bounded_preterm L n l) (ts : dvector (bounded_term L n) l) 
+have h : ∀{l} (t : bounded_preterm L n l) (ts : dvector (bounded_term L n) l)
   (ih_ts : ∀s, ts.pmem s → C s), C (bd_apps t ts),
 begin
   intros, induction t; try {rw ts.zero_eq},
-  { apply hvar }, 
-  { apply hfunc t_f ts ih_ts }, 
-  { apply t_ih_t (t_s::ts), intros t ht, 
-    cases ht, 
+  { apply hvar },
+  { apply hfunc t_f ts ih_ts },
+  { apply t_ih_t (t_s::ts), intros t ht,
+    cases ht,
     { induction ht, apply t_ih_s ([]), intros s hs, cases hs },
     { exact ih_ts t ht }},
 end,
 λt, h t ([]) (by intros s hs; cases hs)
 
 @[elab_as_eliminator] def bounded_term.rec1 {n} {C : bounded_term L (n+1) → Sort v}
-  (hvar : ∀(k : fin (n+1)), C &k)
-  (hfunc : Π {l} (f : L.functions l) (ts : dvector (bounded_term L (n+1)) l) 
-    (ih_ts : ∀t, ts.pmem t → C t), C (bd_apps (bd_func f) ts)) : 
+  (hvar : ∀(k : dfin (n+1)), C &k)
+  (hfunc : Π {l} (f : L.functions l) (ts : dvector (bounded_term L (n+1)) l)
+    (ih_ts : ∀t, ts.pmem t → C t), C (bd_apps (bd_func f) ts)) :
   ∀(t : bounded_term L (n+1)), C t :=
-have h : ∀{l} (t : bounded_preterm L (n+1) l) (ts : dvector (bounded_term L (n+1)) l) 
+have h : ∀{l} (t : bounded_preterm L (n+1) l) (ts : dvector (bounded_term L (n+1)) l)
   (ih_ts : ∀s, ts.pmem s → C s), C (bd_apps t ts),
 begin
   intros, induction t; try {rw ts.zero_eq},
-  { apply hvar }, 
-  { apply hfunc t_f ts ih_ts }, 
-  { apply t_ih_t (t_s::ts), intros t ht, 
-    cases ht, 
+  { apply hvar },
+  { apply hfunc t_f ts ih_ts },
+  { apply t_ih_t (t_s::ts), intros t ht,
+    cases ht,
     { induction ht, apply t_ih_s ([]), intros s hs, cases hs },
     { exact ih_ts t ht }},
 end,
 λt, h t ([]) (by intros s hs; cases hs)
 
-lemma lift_bounded_term_irrel {n : ℕ} : ∀{l} (t : bounded_preterm L n l) (n') {m : ℕ}
-  (h : n ≤ m), t.fst ↑' n' # m = t.fst
-| _ &k           n' m h := 
-  have h' : ¬(m ≤ k.1), from not_le_of_lt (lt_of_lt_of_le k.2 h), by simp [h']
-| _ (bd_func f)  n' m h := by refl
-| _ (bd_app t s) n' m h := by simp [lift_bounded_term_irrel t n' h, lift_bounded_term_irrel s n' h]
+lemma lift_bounded_term_irrel {n : ℕ} {l} (t : bounded_preterm L n l) : ∀ (n') {m : ℕ}
+  (h : n ≤ m), t.fst ↑' n' # m = t.fst :=
+t.fst_bounded.lift_irrel
 
-lemma subst_bounded_term_irrel {n : ℕ} : ∀{l} (t : bounded_preterm L n l) {n'} (s : term L)
-  (h : n ≤ n'), t.fst[s // n'] = t.fst
-| _ &k             n' s h := by simp [lt_of_lt_of_le k.2 h]
-| _ (bd_func f)    n' s h := by refl
-| _ (bd_app t₁ t₂) n' s h := by simp*
+lemma subst_bounded_term_irrel {n : ℕ} {l} (t : bounded_preterm L n l) {n'} : ∀ (s : term L)
+  (h : n ≤ n'), t.fst[s // n'] = t.fst :=
+t.fst_bounded.subst_irrel
 
 /--Given a bounded_preterm of bound n and level l, realize it using (v : dvector S n) and (xs : dvector L l) by the following structural induction:
 
@@ -1397,63 +1438,98 @@ lemma subst_bounded_term_irrel {n : ℕ} : ∀{l} (t : bounded_preterm L n l) {n
 
 3. given an application of terms, replace it with a literal application of terms, with the inner term evaluated at xs.
 --/
-@[simp] def realize_bounded_term {S : Structure L} {n} (v : dvector S n) : 
+@[simp] def realize_bounded_term {S : Structure L} {n} (v : dvector S n) :
   ∀{l} (t : bounded_preterm L n l) (xs : dvector S l), S.carrier
-| _ &k             xs := v.nth k.1 k.2
+| _ &k             xs := v.nth2 k
 | _ (bd_func f)    xs := S.fun_map f xs
 | _ (bd_app t₁ t₂) xs := realize_bounded_term t₁ $ realize_bounded_term t₂ ([])::xs
 
 @[reducible] def realize_closed_term (S : Structure L) (t : closed_term L) : S :=
 realize_bounded_term ([]) t ([])
 
+def realize_is_bounded_term {S : Structure L} {n} (v : dvector S n)
+  {l} (t : preterm L l) (ht : is_bounded_preterm n t) : dvector S l → S.carrier :=
+realize_bounded_term v (bounded_preterm.mk t ht)
+
 lemma realize_bounded_term_eq {S : Structure L} {n} {v₁ : dvector S n} {v₂ : ℕ → S}
-  (hv : ∀k (hk : k < n), v₁.nth k hk = v₂ k) : ∀{l} (t : bounded_preterm L n l)
+  (hv : ∀k, v₁.nth2 k = v₂ k.to_nat) : ∀{l} (t : bounded_preterm L n l)
   (xs : dvector S l), realize_bounded_term v₁ t xs = realize_term v₂ t.fst xs
-| _ &k             xs := hv k.1 k.2
+| _ &k             xs := hv k
 | _ (bd_func f)    xs := by refl
 | _ (bd_app t₁ t₂) xs := by dsimp; simp [realize_bounded_term_eq]
 
-lemma realize_bounded_term_irrel' {S : Structure L} {n n'} {v₁ : dvector S n} {v₂ : dvector S n'} 
-  (h : ∀m (hn : m < n) (hn' : m < n'), v₁.nth m hn = v₂.nth m hn')
-  {l} (t : bounded_preterm L n l) (t' : bounded_preterm L n' l) 
-  (ht : t.fst = t'.fst) (xs : dvector S l) : 
-  realize_bounded_term v₁ t xs = realize_bounded_term v₂ t' xs :=
-begin
-  induction t; cases t'; injection ht with ht₁ ht₂,
-  { simp, cases t'_1; dsimp at ht₁, subst ht₁, exact h t.val t.2 t'_1_is_lt },
-  { subst ht₁, refl },
-  { simp [t_ih_t t'_t ht₁, t_ih_s t'_s ht₂] }
-end
+lemma realize_is_bounded_term_eq {S : Structure L} {n} {v₁ : dvector S n} {v₂ : ℕ → S}
+  (hv : ∀k, v₁.nth2 k = v₂ k.to_nat) {l} {t : preterm L l}
+  (ht : is_bounded_preterm n t) (xs : dvector S l) :
+  realize_is_bounded_term v₁ t ht xs = realize_term v₂ t xs :=
+by rw [realize_is_bounded_term, realize_bounded_term_eq hv, bounded_preterm.fst_mk]
+
+lemma realize_bounded_term_eq' {S : Structure L} {n} {v : dvector S n}
+  {l} (t : bounded_preterm L n l) (xs : dvector S l) :
+  realize_bounded_term v t xs = realize_is_bounded_term v t.fst t.fst_bounded xs :=
+by rw [realize_is_bounded_term, bounded_preterm.mk_fst]
+
+-- lemma realize_bounded_term_irrel' {S : Structure L} {n n'} {v₁ : dvector S n} {v₂ : dvector S n'}
+--   (h : ∀m (hn : m < n) (hn' : m < n'), v₁.nth2 (dfin.of_nat_lt m hn) = v₂.nth2 (dfin.of_nat_lt m hn'))
+--   {l} (t : bounded_preterm L n l) (t' : bounded_preterm L n' l)
+--   (ht : t.fst = t'.fst) (xs : dvector S l) :
+--   realize_bounded_term v₁ t xs = realize_bounded_term v₂ t' xs :=
+-- begin
+--   induction t; cases t'; injection ht with ht₁ ht₂,
+--   { simp, cases t'_1; dsimp at ht₁, subst ht₁, exact h t.val t.2 t'_1_is_lt },
+--   { subst ht₁, refl },
+--   { simp [t_ih_t t'_t ht₁, t_ih_s t'_s ht₂] }
+-- end
+
+lemma realize_bounded_term_irrel_le {S : Structure L} {n n'} (hn : n ≤ n') {v₁ : dvector S n} {v₂ : dvector S n'}
+  (h : ∀m, v₁.nth2 m = v₂.nth2 (m.cast_le hn)) :
+  ∀ {l} {t : preterm L l} (ht : is_bounded_preterm n t) (xs : dvector S l),
+  realize_is_bounded_term v₁ t ht xs = realize_is_bounded_term v₂ t (ht.mono hn) xs
+| _ &k          ht xs := by simp [realize_is_bounded_term, realize_bounded_term];
+  rw h; congr; ext; simp
+| _ (func f)    ht xs := rfl
+| _ (app t₁ t₂) ht xs := begin
+    have IH1 := realize_bounded_term_irrel_le ht.1,
+    have IH2 := realize_bounded_term_irrel_le ht.2,
+    unfold realize_is_bounded_term at IH1 IH2 ⊢,
+    simp [realize_bounded_term, IH1, IH2]
+  end
 
 lemma realize_bounded_term_irrel {S : Structure L} {n} {v₁ : dvector S n}
   (t : bounded_term L n) (t' : closed_term L) (ht : t.fst = t'.fst) (xs : dvector S 0) :
   realize_bounded_term v₁ t xs = realize_closed_term S t' :=
-by cases xs; exact realize_bounded_term_irrel' 
-  (by intros m hm hm'; exfalso; exact not_lt_zero m hm') t t' ht ([])
+begin
+  have : t = t'.cast (nat.zero_le n), {ext, simp [ht]}, subst t,
+  rw [realize_bounded_term_eq', ← realize_bounded_term_irrel_le (nat.zero_le _) (λ m, m.elim0)],
+  { simp [realize_bounded_term_eq', realize_closed_term],
+    cases xs, refl },
+  { simp },
+  { exact xs }
+end
 
-@[simp] def lift_bounded_term_at {n} : ∀{l} (t : bounded_preterm L n l) (n' m : ℕ), 
-  bounded_preterm L (n + n') l
-| _ &k             n' m := if m ≤ k.1 then &(k.add_nat n') else &(k.cast_le $ n.le_add_right n')
-| _ (bd_func f)    n' m := bd_func f
-| _ (bd_app t₁ t₂) n' m := bd_app (lift_bounded_term_at t₁ n' m) $ lift_bounded_term_at t₂ n' m
+-- @[simp] def lift_bounded_term_at {n} : ∀{l} (t : bounded_preterm L n l) (n' m : ℕ),
+--   bounded_preterm L (n + n') l
+-- | _ &k             n' m := if m ≤ k.1 then &(k.add_nat n') else &(k.cast_le $ n.le_add_right n')
+-- | _ (bd_func f)    n' m := bd_func f
+-- | _ (bd_app t₁ t₂) n' m := bd_app (lift_bounded_term_at t₁ n' m) $ lift_bounded_term_at t₂ n' m
 
-notation t ` ↑' `:90 n ` # `:90 m:90 := fol.lift_bounded_term_at t n m -- input ↑ with \u or \upa
+-- notation t ` ↑' `:90 n ` # `:90 m:90 := fol.lift_bounded_term_at t n m -- input ↑ with \u or \upa
 
-@[reducible] def lift_bounded_term {n l} (t : bounded_preterm L n l) (n' : ℕ) : 
-  bounded_preterm L (n + n') l := t ↑' n' # 0
-infix ` ↑ `:100 := fol.lift_bounded_term -- input ↑' with \u or \upa
+-- @[reducible] def lift_bounded_term {n l} (t : bounded_preterm L n l) (n' : ℕ) :
+--   bounded_preterm L (n + n') l := t ↑' n' # 0
+-- infix ` ↑ `:100 := fol.lift_bounded_term -- input ↑' with \u or \upa
 
-@[reducible, simp] def lift_bounded_term1 {n' l} (t : bounded_preterm L n' l) : 
-  bounded_preterm L (n'+1) l := 
-t ↑ 1
+-- @[reducible, simp] def lift_bounded_term1 {n' l} (t : bounded_preterm L n' l) :
+--   bounded_preterm L (n'+1) l :=
+-- t ↑ 1
 
-@[simp] lemma lift_bounded_term_fst {n} : ∀{l} (t : bounded_preterm L n l) (n' m : ℕ), 
-  (t ↑' n' # m).fst = t.fst ↑' n' # m
-| _ &k             n' m := by by_cases h : m ≤ k.1; simp [h, -add_comm]; refl
-| _ (bd_func f)    n' m := by refl
-| _ (bd_app t₁ t₂) n' m := by simp [lift_bounded_term_fst]
+-- @[simp] lemma lift_bounded_term_fst {n} : ∀{l} (t : bounded_preterm L n l) (n' m : ℕ),
+--   (t ↑' n' # m).fst = t.fst ↑' n' # m
+-- | _ &k             n' m := by by_cases h : m ≤ k.1; simp [h, -add_comm]; refl
+-- | _ (bd_func f)    n' m := by refl
+-- | _ (bd_app t₁ t₂) n' m := by simp [lift_bounded_term_fst]
 
--- @[simp] def lift_closed_term_at : ∀{l} (t : closed_preterm L l) (n' m : ℕ), 
+-- @[simp] def lift_closed_term_at : ∀{l} (t : closed_preterm L l) (n' m : ℕ),
 --   bounded_preterm L n' l
 -- | _ &k             n' m := if m ≤ k then _ else &(k.cast_le $ n.le_add_right n')
 -- | _ (bd_func f)    n' m := bd_func f
@@ -1464,94 +1540,94 @@ t ↑ 1
 -- by have := lift_bounded_term_at n m ht; rw [zero_add] at this; exact this
 
 /-- this is t[s//n] for bounded formulae-/
-def subst_bounded_term {n n'} : ∀{l} (t : bounded_preterm L (n+n'+1) l)  
-  (s : bounded_term L n'), bounded_preterm L (n+n') l
-| _ &k             s := 
-  if h : k.1 < n then &⟨k.1, lt_of_lt_of_le h $ n.le_add_right n'⟩ else 
-  if h' : n < k.1 then &⟨k.1-1, (nat.sub_lt_right_iff_lt_add $ one_le_of_lt h').mpr k.2⟩ else 
-  (s ↑ n).cast $ le_of_eq $ add_comm n' n
-| _ (bd_func f)    s := bd_func f
-| _ (bd_app t₁ t₂) s := bd_app (subst_bounded_term t₁ s) (subst_bounded_term t₂ s)
+-- def subst_bounded_term {n n'} : ∀{l} (t : bounded_preterm L (n+n'+1) l)
+--   (s : bounded_term L n'), bounded_preterm L (n+n') l
+-- | _ &k             s :=
+--   if h : k.1 < n then &⟨k.1, lt_of_lt_of_le h $ n.le_add_right n'⟩ else
+--   if h' : n < k.1 then &⟨k.1-1, (nat.sub_lt_right_iff_lt_add $ one_le_of_lt h').mpr k.2⟩ else
+--   (s ↑ n).cast $ le_of_eq $ add_comm n' n
+-- | _ (bd_func f)    s := bd_func f
+-- | _ (bd_app t₁ t₂) s := bd_app (subst_bounded_term t₁ s) (subst_bounded_term t₂ s)
 
-@[simp] lemma subst_bounded_term_var_lt {n n'} (s : bounded_term L n') (k : fin (n+n'+1)) 
-  (h : k.1 < n) : (subst_bounded_term &k s).fst = &k.1 :=
-by simp [h, fol.subst_bounded_term]
+-- @[simp] lemma subst_bounded_term_var_lt {n n'} (s : bounded_term L n') (k : fin (n+n'+1))
+--   (h : k.1 < n) : (subst_bounded_term &k s).fst = &k.1 :=
+-- by simp [h, fol.subst_bounded_term]
 
-@[simp] lemma subst_bounded_term_var_gt {n n'} (s : bounded_term L n') (k : fin (n+n'+1)) 
-  (h : n < k.1) : (subst_bounded_term &k s).fst = &(k.1-1) :=
-have h' : ¬(k.1 < n), from lt_asymm h,
-by simp [h, h', fol.subst_bounded_term]
+-- @[simp] lemma subst_bounded_term_var_gt {n n'} (s : bounded_term L n') (k : fin (n+n'+1))
+--   (h : n < k.1) : (subst_bounded_term &k s).fst = &(k.1-1) :=
+-- have h' : ¬(k.1 < n), from lt_asymm h,
+-- by simp [h, h', fol.subst_bounded_term]
 
-@[simp] lemma subst_bounded_term_var_eq {n n'} (s : bounded_term L n') (k : fin (n+n'+1)) 
-  (h : k.1 = n) : (subst_bounded_term &k s).fst = s.fst ↑ n :=
-have h₂ : ¬(k.1 < n), from λh', lt_irrefl _ $ lt_of_lt_of_le h' $ le_of_eq h.symm,
-have h₃ : ¬(n < k.1), from λh', lt_irrefl _ $ lt_of_lt_of_le h' $ le_of_eq h,
-by simp [subst_bounded_term, h₂, h₃]
+-- @[simp] lemma subst_bounded_term_var_eq {n n'} (s : bounded_term L n') (k : fin (n+n'+1))
+--   (h : k.1 = n) : (subst_bounded_term &k s).fst = s.fst ↑ n :=
+-- have h₂ : ¬(k.1 < n), from λh', lt_irrefl _ $ lt_of_lt_of_le h' $ le_of_eq h.symm,
+-- have h₃ : ¬(n < k.1), from λh', lt_irrefl _ $ lt_of_lt_of_le h' $ le_of_eq h,
+-- by simp [subst_bounded_term, h₂, h₃]
 
-@[simp] lemma subst_bounded_term_bd_app {n n' l} (t₁ : bounded_preterm L (n+n'+1) (l+1)) 
-  (t₂ : bounded_term L (n+n'+1)) (s : bounded_term L n') : 
-  subst_bounded_term (bd_app t₁ t₂) s = bd_app (subst_bounded_term t₁ s) (subst_bounded_term t₂ s) :=
-by refl
+-- @[simp] lemma subst_bounded_term_bd_app {n n' l} (t₁ : bounded_preterm L (n+n'+1) (l+1))
+--   (t₂ : bounded_term L (n+n'+1)) (s : bounded_term L n') :
+--   subst_bounded_term (bd_app t₁ t₂) s = bd_app (subst_bounded_term t₁ s) (subst_bounded_term t₂ s) :=
+-- by refl
 
-@[simp] lemma subst_bounded_term_fst {n n'} : ∀{l} (t : bounded_preterm L (n+n'+1) l)
-  (s : bounded_term L n'), (subst_bounded_term t s).fst = t.fst[s.fst//n]
-| _ &k             s := by apply lt_by_cases k.1 n; intro h; simp [h]
-| _ (bd_func f)    s := by refl
-| _ (bd_app t₁ t₂) s := by simp*
+-- @[simp] lemma subst_bounded_term_fst {n n'} : ∀{l} (t : bounded_preterm L (n+n'+1) l)
+--   (s : bounded_term L n'), (subst_bounded_term t s).fst = t.fst[s.fst//n]
+-- | _ &k             s := by apply lt_by_cases k.1 n; intro h; simp [h]
+-- | _ (bd_func f)    s := by refl
+-- | _ (bd_app t₁ t₂) s := by simp*
 
--- @[simp] lemma subst_bounded_term_var_eq' {n n'} (s : bounded_term L n') (h : n < n+n'+1) : 
+-- @[simp] lemma subst_bounded_term_var_eq' {n n'} (s : bounded_term L n') (h : n < n+n'+1) :
 --   (subst_bounded_term &⟨n, h⟩ s).fst = s.fst ↑ n :=
 -- by simp [subst_bounded_term]
 
-def subst0_bounded_term {n l} (t : bounded_preterm L (n+1) l)
-  (s : bounded_term L n) : bounded_preterm L n l :=
-(subst_bounded_term (t.cast_eq $ (n+1).zero_add.symm) s).cast_eq $ n.zero_add
+-- def subst0_bounded_term {n l} (t : bounded_preterm L (n+1) l)
+--   (s : bounded_term L n) : bounded_preterm L n l :=
+-- (subst_bounded_term (t.cast_eq $ (n+1).zero_add.symm) s).cast_eq $ n.zero_add
 
-notation t `[`:max s ` /0]`:0 := fol.subst0_bounded_term t s
+-- notation t `[`:max s ` /0]`:0 := fol.subst0_bounded_term t s
 
-@[simp] lemma subst0_bounded_term_fst {n l} (t : bounded_preterm L (n+1) l)
-  (s : bounded_term L n) : t[s/0].fst = t.fst[s.fst//0] :=
-by simp [subst0_bounded_term]
+-- @[simp] lemma subst0_bounded_term_fst {n l} (t : bounded_preterm L (n+1) l)
+--   (s : bounded_term L n) : t[s/0].fst = t.fst[s.fst//0] :=
+-- by simp [subst0_bounded_term]
 
-def substmax_bounded_term {n l} (t : bounded_preterm L (n+1) l)
-  (s : closed_term L) : bounded_preterm L n l :=
-subst_bounded_term (by exact t) s
+-- def substmax_bounded_term {n l} (t : bounded_preterm L (n+1) l)
+--   (s : closed_term L) : bounded_preterm L n l :=
+-- subst_bounded_term (by exact t) s
 
-@[simp] lemma substmax_bounded_term_bd_app {n l} (t₁ : bounded_preterm L (n+1) (l+1)) 
-  (t₂ : bounded_term L (n+1)) (s : closed_term L) : 
-  substmax_bounded_term (bd_app t₁ t₂) s = 
-  bd_app (substmax_bounded_term t₁ s) (substmax_bounded_term t₂ s) :=
-by refl
+-- @[simp] lemma substmax_bounded_term_bd_app {n l} (t₁ : bounded_preterm L (n+1) (l+1))
+--   (t₂ : bounded_term L (n+1)) (s : closed_term L) :
+--   substmax_bounded_term (bd_app t₁ t₂) s =
+--   bd_app (substmax_bounded_term t₁ s) (substmax_bounded_term t₂ s) :=
+-- by refl
 
-def substmax_eq_subst0_term {l} (t : bounded_preterm L 1 l) (s : closed_term L) :
-  t[s/0] = substmax_bounded_term t s :=
-by ext; simp [substmax_bounded_term]
+-- def substmax_eq_subst0_term {l} (t : bounded_preterm L 1 l) (s : closed_term L) :
+--   t[s/0] = substmax_bounded_term t s :=
+-- by ext; simp [substmax_bounded_term]
 
-def substmax_var_lt {n} (k : fin (n+1)) (s : closed_term L) (h : k.1 < n) :
-  substmax_bounded_term &k s = &⟨k.1, h⟩ :=
-by ext; simp [substmax_bounded_term, h]
+-- def substmax_var_lt {n} (k : fin (n+1)) (s : closed_term L) (h : k.1 < n) :
+--   substmax_bounded_term &k s = &⟨k.1, h⟩ :=
+-- by ext; simp [substmax_bounded_term, h]
 
-def substmax_var_eq {n} (k : fin (n+1)) (s : closed_term L) (h : k.1 = n) :
-  substmax_bounded_term &k s = s.cast0 n :=
-begin
-  ext, simp [substmax_bounded_term, h], 
-  dsimp only [lift_term], rw [lift_bounded_term_irrel s _ (le_refl _)]
-end
+-- def substmax_var_eq {n} (k : fin (n+1)) (s : closed_term L) (h : k.1 = n) :
+--   substmax_bounded_term &k s = s.cast0 n :=
+-- begin
+--   ext, simp [substmax_bounded_term, h],
+--   dsimp only [lift_term], rw [lift_bounded_term_irrel s _ (le_refl _)]
+-- end
 
-def bounded_term_of_function {l n} (f : L.functions l) : 
+def bounded_term_of_function {l n} (f : L.functions l) :
   arity' (bounded_term L n) (bounded_term L n) l :=
 arity'.of_dvector_map $ bd_apps (bd_func f)
 
 @[simp] lemma realize_bounded_term_bd_app {S : Structure L}
-  {n l} (t : bounded_preterm L n (l+1)) (s : bounded_term L n) (xs : dvector S n) 
+  {n l} (t : bounded_preterm L n (l+1)) (s : bounded_term L n) (xs : dvector S n)
   (xs' : dvector S l) :
-  realize_bounded_term xs (bd_app t s) xs' = 
+  realize_bounded_term xs (bd_app t s) xs' =
   realize_bounded_term xs t (realize_bounded_term xs s ([])::xs') :=
 by refl
 
 @[simp] lemma realize_closed_term_bd_apps {S : Structure L}
   {l} (t : closed_preterm L l) (ts : dvector (closed_term L) l) :
-  realize_closed_term S (bd_apps t ts) = 
+  realize_closed_term S (bd_apps t ts) =
   realize_bounded_term ([]) t (ts.map (λt', realize_bounded_term ([]) t' ([]))) :=
 begin
   induction ts generalizing t, refl, apply ts_ih (bd_app t ts_x)
@@ -1569,20 +1645,19 @@ end
 /- When realizing a closed term, we can replace the realizing dvector with [] -/
 @[simp] lemma realize_closed_term_v_irrel {S : Structure L} {n} {v : dvector S n} {t : bounded_term L 0} : realize_bounded_term v (t.cast (by {simp})) ([]) = realize_closed_term S t :=
 begin
-  revert t, refine bounded_term.rec _ _,
-    {intro k, cases k, exfalso, exact not_lt_zero k_val k_is_lt},
+  revert t, refine bounded_term.rec (λ k, k.elim0) _,
     {intros, simp[realize_bounded_term_bd_apps], congr' 1,
       apply dvector.map_congr_pmem, intros x Hx, rw[ih_ts x Hx]}
 end
 
 /- this is the same as realize_bounded_term, we should probably have a common generalization of this definition -/
--- @[simp] def substitute_bounded_term {n n'} (v : dvector (bounded_term n') n) : 
+-- @[simp] def substitute_bounded_term {n n'} (v : dvector (bounded_term n') n) :
 --   ∀{l} (t : bounded_term L n l, bounded_preterm L n' l
 -- | _ _ &k          := v.nth k hk
 -- | _ _ (bd_func f)             := bd_func f
 -- | _ _ (bd_app t₁ t₂) := bd_app (substitute_bounded_term ht₁) $ substitute_bounded_term ht₂
 
--- def substitute_bounded_term {n n' l} (t : bounded_preterm L n l) 
+-- def substitute_bounded_term {n n' l} (t : bounded_preterm L n l)
 --   (v : dvector (bounded_term n') n) : bounded_preterm L n' l :=
 -- substitute_bounded_term v t.snd
 
@@ -1607,9 +1682,9 @@ instance nonempty_bounded_formula (n : ℕ) : nonempty $ bounded_formula L n :=
   nonempty.intro (by constructor)
 
 -- @[reducible, simp] def bd_falsum' {n} : bounded_formula L n := bd_falsum
--- @[reducible, simp] def bd_equal' {n} (t₁ t₂ : bounded_term L n) : bounded_formula L n := 
--- bd_equal t₁ t₂ 
--- @[reducible, simp] def bd_imp' {n} (f₁ f₂ : bounded_formula L n) : bounded_formula L n := 
+-- @[reducible, simp] def bd_equal' {n} (t₁ t₂ : bounded_term L n) : bounded_formula L n :=
+-- bd_equal t₁ t₂
+-- @[reducible, simp] def bd_imp' {n} (f₁ f₂ : bounded_formula L n) : bounded_formula L n :=
 -- bd_imp f₁ f₂
 notation `⊥` := fol.bounded_preformula.bd_falsum -- input: \bot
 infix ` ≃ `:88 := fol.bounded_preformula.bd_equal -- input \~- or \simeq
@@ -1631,7 +1706,7 @@ def bd_apps_rel : ∀{n l} (f : bounded_preformula L n l) (ts : dvector (bounded
 | _ _ f []      := f
 | _ _ f (t::ts) := bd_apps_rel (bd_apprel f t) ts
 
-@[simp] lemma bd_apps_rel_zero {n} (f : bounded_formula L n) (ts : dvector (bounded_term L n) 0) : 
+@[simp] lemma bd_apps_rel_zero {n} (f : bounded_formula L n) (ts : dvector (bounded_term L n) 0) :
   bd_apps_rel f ts = f :=
 by cases ts; refl
 
@@ -1651,7 +1726,7 @@ local attribute [extensionality] fin.eq_of_veq
   f₁ = f₂ :=
 begin
   induction f₁; cases f₂; injection h with h₁ h₂,
-  { refl }, 
+  { refl },
   { congr1; apply bounded_preterm.eq; assumption },
   { rw h₁ },
   { congr1, exact f₁_ih h₁, exact bounded_preterm.eq h₂ },
@@ -1659,7 +1734,7 @@ begin
   { rw [f₁_ih h₁] }
 end
 
-@[simp] protected def cast : ∀ {n m l} (h : n ≤ m)  (f : bounded_preformula L n l), 
+@[simp] protected def cast : ∀ {n m l} (h : n ≤ m)  (f : bounded_preformula L n l),
   bounded_preformula L m l
 | _ _ _ h bd_falsum       := bd_falsum
 | _ _ _ h (t₁ ≃ t₂)       := t₁.cast h ≃ t₂.cast h
@@ -1683,7 +1758,7 @@ f.cast $ ge_of_eq h
 protected def cast1 {n l} (f : bounded_preformula L n l) : bounded_preformula L (n+1) l :=
 f.cast $ n.le_add_right 1
 
-@[simp] lemma cast_fst : ∀ {l n m} (h : n ≤ m) (f : bounded_preformula L n l), 
+@[simp] lemma cast_fst : ∀ {l n m} (h : n ≤ m) (f : bounded_preformula L n l),
   (f.cast h).fst = f.fst
 | _ _ _ h bd_falsum       := by refl
 | _ _ _ h (t₁ ≃ t₂)       := by simp
@@ -1692,9 +1767,9 @@ f.cast $ n.le_add_right 1
 | _ _ _ h (f₁ ⟹ f₂)      := by simp*
 | _ _ _ h (∀' f)          := by simp*
 
-@[simp] lemma cast_eq_fst {l n m} (h : n = m) (f : bounded_preformula L n l) : 
+@[simp] lemma cast_eq_fst {l n m} (h : n = m) (f : bounded_preformula L n l) :
   (f.cast_eq h).fst = f.fst := f.cast_fst _
-@[simp] lemma cast1_fst {l n} (f : bounded_preformula L n l) : 
+@[simp] lemma cast1_fst {l n} (f : bounded_preformula L n l) :
   f.cast1.fst = f.fst := f.cast_fst _
 
 /- A bounded_preformula is qf if the underlying preformula is qf -/
@@ -1707,7 +1782,7 @@ namespace presentence
 protected def cast0 {l} (n) (f : presentence L l) : bounded_preformula L n l :=
 f.cast n.zero_le
 
-@[simp] lemma cast0_fst {l} (n) (f : presentence L l) : 
+@[simp] lemma cast0_fst {l} (n) (f : presentence L l) :
   (f.cast0 n).fst = f.fst := f.cast_fst _
 
 end presentence
@@ -1736,7 +1811,7 @@ lemma subst_bounded_formula_irrel : ∀{n l} (f : bounded_preformula L n l) {n'}
 lemma subst_sentence_irrel (f : sentence L) (n) (s : term L) : f.fst[s // n] = f.fst :=
 subst_bounded_formula_irrel f s n.zero_le
 
-@[simp] def realize_bounded_formula {S : Structure L} : 
+@[simp] def realize_bounded_formula {S : Structure L} :
   ∀{n l} (v : dvector S n) (f : bounded_preformula L n l) (xs : dvector S l), Prop
 | _ _ v bd_falsum       xs := false
 | _ _ v (t₁ ≃ t₂)       xs := realize_bounded_term v t₁ xs = realize_bounded_term v t₂ xs
@@ -1754,19 +1829,19 @@ lemma realize_bounded_formula_iff {S : Structure L} : ∀{n} {v₁ : dvector S n
 | _ _ _ hv _ bd_falsum       xs := by refl
 | _ _ _ hv _ (t₁ ≃ t₂)       xs := by apply eq.congr; apply realize_bounded_term_eq hv
 | _ _ _ hv _ (bd_rel R)      xs := by refl
-| _ _ _ hv _ (bd_apprel f t) xs := 
+| _ _ _ hv _ (bd_apprel f t) xs :=
   by simp [realize_bounded_term_eq hv, realize_bounded_formula_iff hv]
-| _ _ _ hv _ (f₁ ⟹ f₂)      xs := 
+| _ _ _ hv _ (f₁ ⟹ f₂)      xs :=
   by simp [realize_bounded_formula_iff hv]
 | _ _ _ hv _ (∀' f)          xs :=
-  begin 
+  begin
     apply forall_congr, intro x, apply realize_bounded_formula_iff,
     intros k hk, cases k, refl, apply hv
   end
 
-@[simp] def lift_bounded_formula_at : ∀{n l} (f : bounded_preformula L n l) (n' m : ℕ), 
+@[simp] def lift_bounded_formula_at : ∀{n l} (f : bounded_preformula L n l) (n' m : ℕ),
   bounded_preformula L (n + n') l
-| _ _ bd_falsum       n' m := ⊥ 
+| _ _ bd_falsum       n' m := ⊥
 | _ _ (t₁ ≃ t₂)       n' m := t₁ ↑' n' # m ≃ t₂ ↑' n' # m
 | _ _ (bd_rel R)      n' m := bd_rel R
 | _ _ (bd_apprel f t) n' m := bd_apprel (lift_bounded_formula_at f n' m) $ t ↑' n' # m
@@ -1775,15 +1850,15 @@ lemma realize_bounded_formula_iff {S : Structure L} : ∀{n} {v₁ : dvector S n
 
 notation f ` ↑' `:90 n ` # `:90 m:90 := fol.lift_bounded_formula_at f n m -- input ↑ with \u or \upa
 
-@[reducible] def lift_bounded_formula {n l} (f : bounded_preformula L n l) (n' : ℕ) : 
+@[reducible] def lift_bounded_formula {n l} (f : bounded_preformula L n l) (n' : ℕ) :
   bounded_preformula L (n + n') l := f ↑' n' # 0
 infix ` ↑ `:100 := fol.lift_bounded_formula -- input ↑' with \u or \upa
 
-@[reducible, simp] def lift_bounded_formula1 {n' l} (f : bounded_preformula L n' l) : 
-  bounded_preformula L (n'+1) l := 
+@[reducible, simp] def lift_bounded_formula1 {n' l} (f : bounded_preformula L n' l) :
+  bounded_preformula L (n'+1) l :=
 f ↑ 1
 
-@[simp] lemma lift_bounded_formula_fst : ∀{n l} (f : bounded_preformula L n l) (n' m : ℕ), 
+@[simp] lemma lift_bounded_formula_fst : ∀{n l} (f : bounded_preformula L n l) (n' m : ℕ),
   (f ↑' n' # m).fst = f.fst ↑' n' # m
 | _ _ bd_falsum       n' m := by refl
 | _ _ (t₁ ≃ t₂)       n' m := by simp
@@ -1792,34 +1867,34 @@ f ↑ 1
 | _ _ (f₁ ⟹ f₂)      n' m := by simp*
 | _ _ (∀' f)          n' m := by simp*
 
-def formula_below {n n' l} (f : bounded_preformula L (n+n'+1) l)  
+def formula_below {n n' l} (f : bounded_preformula L (n+n'+1) l)
   (s : bounded_term L n') : bounded_preformula L (n+n') l :=
 begin
-  have : {f' : preformula L l // f.fst = f' } := ⟨f.fst, rfl⟩, 
+  have : {f' : preformula L l // f.fst = f' } := ⟨f.fst, rfl⟩,
   cases this with f' pf, induction f' generalizing n; cases f; injection pf with pf₁ pf₂,
   { exact ⊥ },
   { exact subst_bounded_term f_t₁ s ≃ subst_bounded_term f_t₂ s },
   { exact bd_rel f_R },
   { exact bd_apprel (f'_ih f_f pf₁) (subst_bounded_term f_t s) },
   { exact f'_ih_f₁ f_f₁ pf₁ ⟹ f'_ih_f₂ f_f₂ pf₂ },
-  { refine ∀' (f'_ih (f_f.cast_eq $ congr_arg succ $ (succ_add n n').symm) $ 
-      (f_f.cast_eq_fst _).trans pf₁).cast_eq (succ_add n n') }  
+  { refine ∀' (f'_ih (f_f.cast_eq $ congr_arg succ $ (succ_add n n').symm) $
+      (f_f.cast_eq_fst _).trans pf₁).cast_eq (succ_add n n') }
 end
 
 /- f[s//n] for bounded_formula, requiring an extra proof that (n+n'+1 = n'') -/
-@[simp] def subst_bounded_formula : ∀{n n' n'' l} (f : bounded_preformula L n'' l)  
+@[simp] def subst_bounded_formula : ∀{n n' n'' l} (f : bounded_preformula L n'' l)
   (s : bounded_term L n') (h : n+n'+1 = n''), bounded_preformula L (n+n') l
-| _ _ _ _ bd_falsum       s rfl := ⊥ 
+| _ _ _ _ bd_falsum       s rfl := ⊥
 | _ _ _ _ (t₁ ≃ t₂)       s rfl := subst_bounded_term t₁ s ≃ subst_bounded_term t₂ s
 | _ _ _ _ (bd_rel R)      s rfl := bd_rel R
 | _ _ _ _ (bd_apprel f t) s rfl := bd_apprel (subst_bounded_formula f s rfl) (subst_bounded_term t s)
 | _ _ _ _ (f₁ ⟹ f₂)      s rfl := subst_bounded_formula f₁ s rfl ⟹ subst_bounded_formula f₂ s rfl
-| _ _ _ _ (∀' f)          s rfl := 
+| _ _ _ _ (∀' f)          s rfl :=
   ∀' (subst_bounded_formula f s $ by simp [succ_add]).cast_eq (succ_add _ _)
 
 notation f `[`:95 s ` // `:95 n ` // `:95 h `]`:0 := @fol.subst_bounded_formula _ n _ _ _ f s h
 
-@[simp] def subst_bounded_formula_fst : ∀{n n' n'' l} (f : bounded_preformula L n'' l)  
+@[simp] def subst_bounded_formula_fst : ∀{n n' n'' l} (f : bounded_preformula L n'' l)
   (s : bounded_term L n') (h : n+n'+1 = n''),
   (subst_bounded_formula f s h).fst = f.fst[s.fst//n]
 | _ _ _ _ bd_falsum       s rfl := by refl
@@ -1829,10 +1904,10 @@ notation f `[`:95 s ` // `:95 n ` // `:95 h `]`:0 := @fol.subst_bounded_formula 
 | _ _ _ _ (f₁ ⟹ f₂)      s rfl := by simp*
 | _ _ _ _ (∀' f)          s rfl := by simp*
 
-lemma realize_bounded_formula_irrel' {S : Structure L} {n n'} {v₁ : dvector S n} {v₂ : dvector S n'} 
+lemma realize_bounded_formula_irrel' {S : Structure L} {n n'} {v₁ : dvector S n} {v₂ : dvector S n'}
   (h : ∀m (hn : m < n) (hn' : m < n'), v₁.nth m hn = v₂.nth m hn')
-  {l} (f : bounded_preformula L n l) (f' : bounded_preformula L n' l) 
-  (hf : f.fst = f'.fst) (xs : dvector S l) : 
+  {l} (f : bounded_preformula L n l) (f' : bounded_preformula L n' l)
+  (hf : f.fst = f'.fst) (xs : dvector S l) :
   realize_bounded_formula v₁ f xs ↔ realize_bounded_formula v₂ f' xs :=
 begin
   induction f generalizing n'; cases f'; injection hf with hf₁ hf₂,
@@ -1849,10 +1924,10 @@ end
 lemma realize_bounded_formula_irrel {S : Structure L} {n} {v₁ : dvector S n}
   (f : bounded_formula L n) (f' : sentence L) (hf : f.fst = f'.fst) (xs : dvector S 0) :
   realize_bounded_formula v₁ f xs ↔ realize_sentence S f' :=
-by cases xs; exact realize_bounded_formula_irrel' 
+by cases xs; exact realize_bounded_formula_irrel'
   (by intros m hm hm'; exfalso; exact not_lt_zero m hm') f f' hf ([])
 
-def bounded_formula_of_relation {l n} (f : L.relations l) : 
+def bounded_formula_of_relation {l n} (f : L.relations l) :
   arity' (bounded_term L n) (bounded_formula L n) l :=
 arity'.of_dvector_map $ bd_apps_rel (bd_rel f)
 
@@ -1860,7 +1935,7 @@ arity'.of_dvector_map $ bd_apps_rel (bd_rel f)
   (H0 : Π {n}, C n 0 ⊥)
   (H1 : Π {n} (t₁ t₂ : bounded_term L (n+1)), C n 0 (t₁ ≃ t₂))
   (H2 : Π {n l : ℕ} (R : L.relations l), C n l (bd_rel R))
-  (H3 : Π {n l : ℕ} (f : bounded_preformula L (n+1) (l + 1)) (t : bounded_term L (n+1)) 
+  (H3 : Π {n l : ℕ} (f : bounded_preformula L (n+1) (l + 1)) (t : bounded_term L (n+1))
     (ih : C n (l + 1) f), C n l (bd_apprel f t))
   (H4 : Π {n} (f₁ f₂ : bounded_formula L (n+1)) (ih₁ : C n 0 f₁) (ih₂ : C n 0 f₂), C n 0 (f₁ ⟹ f₂))
   (H5 : Π {n} (f : bounded_formula L (n+2)) (ih : C (n+1) 0 f), C n 0 (∀' f)) :
@@ -1872,7 +1947,7 @@ let C' : Πn l, bounded_preformula L n l → Sort v :=
 end in
 begin
   have : ∀{{n l}} (f : bounded_preformula L n l), C' n l f,
-  { intros n l, 
+  { intros n l,
     refine bounded_preformula.rec _ _ _ _ _ _; clear n l; intros; cases n; try {exact punit.star},
     apply H0, apply H1, apply H2, apply H3 _ _ ih, apply H4 _ _ ih_f₁ ih_f₂, apply H5 _ ih },
   intros n l f, apply this f
@@ -1881,12 +1956,12 @@ end
 @[elab_as_eliminator] def bounded_formula.rec1 {C : Πn, bounded_formula L (n+1) → Sort v}
   (hfalsum : Π {n}, C n ⊥)
   (hequal : Π {n} (t₁ t₂ : bounded_term L (n+1)), C n (t₁ ≃ t₂))
-  (hrel : Π {n l : ℕ} (R : L.relations l) (ts : dvector (bounded_term L (n+1)) l), 
+  (hrel : Π {n l : ℕ} (R : L.relations l) (ts : dvector (bounded_term L (n+1)) l),
     C n (bd_apps_rel (bd_rel R) ts))
   (himp : Π {n} {f₁ f₂ : bounded_formula L (n+1)} (ih₁ : C n f₁) (ih₂ : C n f₂), C n (f₁ ⟹ f₂))
-  (hall : Π {n} {f : bounded_formula L (n+2)} (ih : C (n+1) f), C n (∀' f)) 
+  (hall : Π {n} {f : bounded_formula L (n+2)} (ih : C (n+1) f), C n (∀' f))
   {{n : ℕ}} (f : bounded_formula L (n+1)) : C n f :=
-have h : ∀{n l} (f : bounded_preformula L (n+1) l) (ts : dvector (bounded_term L (n+1)) l), 
+have h : ∀{n l} (f : bounded_preformula L (n+1) l) (ts : dvector (bounded_term L (n+1)) l),
   C n (bd_apps_rel f ts),
 begin
   refine bounded_preformula.rec1 _ _ _ _ _ _; intros; try {rw ts.zero_eq},
@@ -1898,12 +1973,12 @@ h f ([])
 @[elab_as_eliminator] def bounded_formula.rec {C : Πn, bounded_formula L n → Sort v}
   (hfalsum : Π {n}, C n ⊥)
   (hequal : Π {n} (t₁ t₂ : bounded_term L n), C n (t₁ ≃ t₂))
-  (hrel : Π {n l : ℕ} (R : L.relations l) (ts : dvector (bounded_term L n) l), 
+  (hrel : Π {n l : ℕ} (R : L.relations l) (ts : dvector (bounded_term L n) l),
     C n (bd_apps_rel (bd_rel R) ts))
   (himp : Π {n} {f₁ f₂ : bounded_formula L n} (ih₁ : C n f₁) (ih₂ : C n f₂), C n (f₁ ⟹ f₂))
-  (hall : Π {n} {f : bounded_formula L (n+1)} (ih : C (n+1) f), C n (∀' f)) : 
+  (hall : Π {n} {f : bounded_formula L (n+1)} (ih : C (n+1) f), C n (∀' f)) :
   ∀{{n : ℕ}} (f : bounded_formula L n), C n f :=
-have h : ∀{n l} (f : bounded_preformula L n l) (ts : dvector (bounded_term L n) l), 
+have h : ∀{n l} (f : bounded_preformula L n l) (ts : dvector (bounded_term L n) l),
   C n (bd_apps_rel f ts),
 begin
   intros, induction f; try {rw ts.zero_eq},
@@ -1922,19 +1997,19 @@ by apply subst_bounded_formula f s rfl
 --   substmax_bounded_formula (bd_rel R : bounded_preformula L (n+1) l) s = bd_rel R := by refl
 -- @[simp] lemma substmax_bounded_formula_bd_apprel {n l} (f : bounded_preformula L (n+1) (l+1))
 --   (t : bounded_term L (n+1)) (s : closed_term L) :
---   substmax_bounded_formula (bd_apprel f t) s = 
+--   substmax_bounded_formula (bd_apprel f t) s =
 --   bd_apprel (substmax_bounded_formula f s) (substmax_bounded_term t s) := by refl
--- @[simp] lemma substmax_bounded_formula_bd_imp {n} (f₁ f₂ : bounded_formula L (n+1)) 
+-- @[simp] lemma substmax_bounded_formula_bd_imp {n} (f₁ f₂ : bounded_formula L (n+1))
 --   (s : closed_term L) :
---   substmax_bounded_formula (f₁ ⟹ f₂) s = 
+--   substmax_bounded_formula (f₁ ⟹ f₂) s =
 --   substmax_bounded_formula f₁ s ⟹ substmax_bounded_formula f₂ s := by refl
-@[simp] lemma substmax_bounded_formula_bd_all {n} (f : bounded_formula L (n+2)) 
+@[simp] lemma substmax_bounded_formula_bd_all {n} (f : bounded_formula L (n+2))
   (s : closed_term L) :
   substmax_bounded_formula (∀' f) s = ∀' substmax_bounded_formula f s := by ext; simp
 
-lemma substmax_bounded_formula_bd_apps_rel {n l} (f : bounded_preformula L (n+1) l) 
+lemma substmax_bounded_formula_bd_apps_rel {n l} (f : bounded_preformula L (n+1) l)
   (t : closed_term L) (ts : dvector (bounded_term L (n+1)) l) :
-  substmax_bounded_formula (bd_apps_rel f ts) t = 
+  substmax_bounded_formula (bd_apps_rel f ts) t =
   bd_apps_rel (substmax_bounded_formula f t) (ts.map $ λt', substmax_bounded_term t' t) :=
 begin
   induction ts generalizing f, refl, apply ts_ih (bd_apprel f ts_x)
@@ -1960,7 +2035,7 @@ by ext; simp [substmax_bounded_formula]
 -- f [bounded_term_of_closed_term t/0]
 
 
-infix ` ⊨ `:51 := fol.realize_sentence -- input using \|= or \vDash, but not using \models 
+infix ` ⊨ `:51 := fol.realize_sentence -- input using \|= or \vDash, but not using \models
 
 @[simp] lemma realize_sentence_false {S : Structure L} : S ⊨ (⊥ : sentence L) ↔ false :=
 by refl
@@ -1968,7 +2043,7 @@ by refl
 @[simp]lemma false_of_satisfied_false {S : Structure L} :  (S ⊨ (⊥ : sentence L)) → false
 := by simp only [realize_sentence_false, imp_self]
 
-@[simp] lemma realize_sentence_imp {S : Structure L} {f₁ f₂ : sentence L} : 
+@[simp] lemma realize_sentence_imp {S : Structure L} {f₁ f₂ : sentence L} :
   S ⊨ f₁ ⟹ f₂ ↔ (S ⊨ f₁ → S ⊨ f₂) :=
 by refl
 @[simp] lemma realize_sentence_not {S : Structure L} {f : sentence L} : S ⊨ ∼f ↔ ¬ S ⊨ f :=
@@ -1998,7 +2073,7 @@ end
 
 lemma realize_bounded_formula_bd_apps_rel {S : Structure L}
   {n l} (xs : dvector S n) (f : bounded_preformula L n l) (ts : dvector (bounded_term L n) l) :
-  realize_bounded_formula xs (bd_apps_rel f ts) ([]) ↔ 
+  realize_bounded_formula xs (bd_apps_rel f ts) ([]) ↔
   realize_bounded_formula xs f (ts.map (λt, realize_bounded_term xs t ([]))) :=
 begin
   induction ts generalizing f, refl, apply ts_ih (bd_apprel f ts_x)
@@ -2018,11 +2093,11 @@ lemma realize_sentence_equal {S : Structure L} (t₁ t₂ : closed_term L) :
   S ⊨ t₁ ≃ t₂ ↔ realize_closed_term S t₁ = realize_closed_term S t₂  :=
 by refl
 
-lemma realize_sentence_iff {S : Structure L} (v : ℕ → S) (f : sentence L) : 
+lemma realize_sentence_iff {S : Structure L} (v : ℕ → S) (f : sentence L) :
   realize_sentence S f ↔ realize_formula v f.fst ([]) :=
 realize_bounded_formula_iff (λk hk, by exfalso; exact not_lt_zero k hk) f _
 
-lemma realize_sentence_of_satisfied_in {S : Structure L} [HS : nonempty S] {f : sentence L} 
+lemma realize_sentence_of_satisfied_in {S : Structure L} [HS : nonempty S] {f : sentence L}
   (H : S ⊨ f.fst) : S ⊨ f :=
 begin unfreezeI, induction HS with x, exact (realize_sentence_iff (λn, x) f).mpr (H _) end
 
@@ -2050,14 +2125,14 @@ infix ` ⊢ `:51 := fol.sprf -- input: \|- or \vdash
 def sprovable (T : Theory L) (f : sentence L) := T.fst ⊢' f.fst
 infix ` ⊢' `:51 := fol.sprovable -- input: \|- or \vdash
 
-def saxm {T : Theory L} {A : sentence L} (H : A ∈ T) : T ⊢ A := 
+def saxm {T : Theory L} {A : sentence L} (H : A ∈ T) : T ⊢ A :=
 by apply axm; apply mem_image_of_mem _ H
 
 def saxm1 {T : Theory L} {A : sentence L} : insert A T ⊢ A := by apply saxm; left; refl
-def saxm2 {T : Theory L} {A B : sentence L} : insert A (insert B T) ⊢ B := 
+def saxm2 {T : Theory L} {A B : sentence L} : insert A (insert B T) ⊢ B :=
 by apply saxm; right; left; refl
 
-def simpI {T : Theory L} {A B : sentence L} (H : insert A T ⊢ B) : T ⊢ A ⟹ B := 
+def simpI {T : Theory L} {A B : sentence L} (H : insert A T ⊢ B) : T ⊢ A ⟹ B :=
 begin
   apply impI, simp[sprf, Theory.fst, image_insert_eq] at H, assumption
 end
@@ -2065,8 +2140,8 @@ end
 lemma simpI' {T : Theory L} {A B : sentence L} (H : insert A T ⊢' B) : T ⊢' A ⟹ B :=
   H.map simpI
 
-def simpE {T : Theory L} (A : sentence L) {B : sentence L} (H₁ : T ⊢ A ⟹ B) (H₂ : T ⊢ A) : 
-  T ⊢ B := 
+def simpE {T : Theory L} (A : sentence L) {B : sentence L} (H₁ : T ⊢ A ⟹ B) (H₂ : T ⊢ A) :
+  T ⊢ B :=
 by apply impE A.fst H₁ H₂
 
 lemma fst_commutes_with_imp {T : Theory L} (A B : sentence L) : (A ⟹ B).fst = A.fst ⟹ B.fst := by refl
@@ -2117,7 +2192,7 @@ begin
   apply nonempty.iff, exact double_negation_elim, intro P, apply impI,
   apply @not_and_self _ _ f.fst, apply andI, exact weakening1 P,
   apply axm, simp
-end 
+end
 
 def sweakening {T T' : Theory L} (h_sub : T' ⊆ T) {ψ : sentence L} (h : T' ⊢ ψ) : T ⊢ ψ :=
 weakening (image_subset _ h_sub) h
@@ -2125,26 +2200,26 @@ weakening (image_subset _ h_sub) h
 def sweakening1 {T : Theory L} {ψ₁ ψ₂ : sentence L} (h : T ⊢ ψ₂) : insert ψ₁ T ⊢ ψ₂ :=
 sweakening (subset_insert ψ₁ T) h
 
-def sweakening2 {T : Theory L} {ψ₁ ψ₂ ψ₃ : sentence L} (h : insert ψ₁ T ⊢ ψ₃) : 
+def sweakening2 {T : Theory L} {ψ₁ ψ₂ ψ₃ : sentence L} (h : insert ψ₁ T ⊢ ψ₃) :
   insert ψ₁ (insert ψ₂ T) ⊢ ψ₃ :=
 sweakening (insert_subset_insert (subset_insert _ T)) h
 
 def sprovable_of_provable {T : Theory L} {f : sentence L} (h : T.fst ⊢ f.fst) : T ⊢ f := h
 def provable_of_sprovable {T : Theory L} {f : sentence L} (h : T ⊢ f) : T.fst ⊢ f.fst := h
 def sprovable_of_sprf {T : Theory L} {f : sentence L} (h : T ⊢ f) : T ⊢' f := ⟨h⟩
-def sprovable.elim {P : Prop} {T : Theory L} {f : sentence L} (ih : T ⊢ f → P) (h : T ⊢' f) : P := 
+def sprovable.elim {P : Prop} {T : Theory L} {f : sentence L} (ih : T ⊢ f → P) (h : T ⊢' f) : P :=
 by unfreezeI; cases h with h; exact ih h
 
 -- def sprovable_of_sprovable_lift_at {T : Theory L} (n m : ℕ) {f : formula L} (h : T.fst ⊢ f ↑' n # m) :
---   T.fst ⊢ f := 
+--   T.fst ⊢ f :=
 -- sorry
 
--- def sprovable_of_sprovable_lift {T : Theory L} {f : formula L} (h : T.fst ⊢ f ↑ 1) : T.fst ⊢ f := 
+-- def sprovable_of_sprovable_lift {T : Theory L} {f : formula L} (h : T.fst ⊢ f ↑ 1) : T.fst ⊢ f :=
 -- sprovable_of_sprovable_lift_at 1 0 h
 
-def sprovable_lift {T : Theory L} {f : formula L} (h : T.fst ⊢ f) : T.fst ⊢ f ↑ 1 := 
+def sprovable_lift {T : Theory L} {f : formula L} (h : T.fst ⊢ f) : T.fst ⊢ f ↑ 1 :=
 begin
-  have := prf_lift 1 0 h, dsimp [Theory.fst] at this, 
+  have := prf_lift 1 0 h, dsimp [Theory.fst] at this,
   rw [image_image, image_congr' lift_sentence_irrel] at this, exact this
 end
 
@@ -2152,7 +2227,7 @@ def all_sprovable (T T' : Theory L) := ∀(f ∈ T'), T ⊢ f
 infix ` ⊢ `:51 := fol.all_sprovable -- input: \|- or \vdash
 
 def all_realize_sentence (S : Structure L) (T : Theory L) := ∀{{f}}, f ∈ T → S ⊨ f
-infix ` ⊨ `:51 := fol.all_realize_sentence -- input using \|= or \vDash, but not using \models 
+infix ` ⊨ `:51 := fol.all_realize_sentence -- input using \|= or \vDash, but not using \models
 
 lemma all_realize_sentence_axm {S : Structure L} {f : sentence L} {T : Theory L} : ∀ (H : S ⊨ insert f T), S ⊨ f ∧ S ⊨ T :=
 λ H, ⟨by {apply H, exact or.inl rfl}, by {intros ψ hψ, apply H, exact or.inr hψ}⟩
@@ -2167,13 +2242,13 @@ end
 @[simp]lemma all_realize_sentence_singleton {S : Structure L} {f : sentence L} : S ⊨ {f} ↔ S ⊨ f :=
   ⟨by{intro H, apply H, exact or.inl rfl}, by {intros H g Hg, repeat{cases Hg}, assumption}⟩
 
-def ssatisfied (T : Theory L) (f : sentence L) := 
+def ssatisfied (T : Theory L) (f : sentence L) :=
 ∀{{S : Structure L}}, nonempty S → S ⊨ T → S ⊨ f
 
-infix ` ⊨ `:51 := fol.ssatisfied -- input using \|= or \vDash, but not using \models 
+infix ` ⊨ `:51 := fol.ssatisfied -- input using \|= or \vDash, but not using \models
 
 def all_ssatisfied (T T' : Theory L) := ∀(f ∈ T'), T ⊨ f
-infix ` ⊨ `:51 := fol.all_ssatisfied -- input using \|= or \vDash, but not using \models 
+infix ` ⊨ `:51 := fol.all_ssatisfied -- input using \|= or \vDash, but not using \models
 
 def satisfied_of_ssatisfied {T : Theory L} {f : sentence L} (H : T ⊨ f) : T.fst ⊨ f.fst :=
 begin
@@ -2200,14 +2275,14 @@ def satisfied_iff_ssatisfied {T : Theory L} {f : sentence L} : T ⊨ f ↔ T.fst
 def all_satisfied_sentences_iff {T T' : Theory L} : T ⊨ T' ↔ T.fst ⊨ T'.fst :=
 ⟨all_satisfied_of_all_ssatisfied, all_ssatisfied_of_all_satisfied⟩
 
-def ssatisfied_snot {S : Structure L} {f : sentence L} (hS : ¬(S ⊨ f)) : S ⊨ ∼ f := 
+def ssatisfied_snot {S : Structure L} {f : sentence L} (hS : ¬(S ⊨ f)) : S ⊨ ∼ f :=
 by exact hS
 
 def Model (T : Theory L) : Type (u+1) := Σ' (S : Structure L), S ⊨ T
 
 @[reducible]def Model_ssatisfied {T : Theory L} (M : Model T) (ψ : sentence L) := M.fst ⊨ ψ
 
-infix ` ⊨ `:51 := fol.Model_ssatisfied -- input using \|= or \vDash, but not using \models 
+infix ` ⊨ `:51 := fol.Model_ssatisfied -- input using \|= or \vDash, but not using \models
 
 @[simp] lemma false_of_Model_absurd {T : Theory L} (M : Model T) {ψ : sentence L} (h : M ⊨ ψ) (h' : M ⊨ ∼ψ) : false :=
 by {unfold Model_ssatisfied at *, simp[*,-h'] at h', exact h'}
@@ -2222,7 +2297,7 @@ begin
   exact H h_nonempty M.snd
 end
 
---infix ` ⊨ `:51 := fol.ssatisfied -- input using \|= or \vDash, but not using \models 
+--infix ` ⊨ `:51 := fol.ssatisfied -- input using \|= or \vDash, but not using \models
 
 /- consistent theories -/
 def is_consistent (T : Theory L) := ¬(T ⊢' (⊥ : sentence L))
@@ -2233,19 +2308,19 @@ H
 protected def is_consistent.elim {T : Theory L} (H : is_consistent T) : ¬ T ⊢' (⊥ : sentence L)
 | H' := H H'
 
-lemma consis_not_of_not_provable {L} {T : Theory L} {f : sentence L} : 
+lemma consis_not_of_not_provable {L} {T : Theory L} {f : sentence L} :
   ¬ T ⊢' f → is_consistent (T ∪ {∼f}) :=
 begin
-  intros h₁ h₂, cases h₂ with h₂, simp only [*, set.union_singleton] at h₂, 
+  intros h₁ h₂, cases h₂ with h₂, simp only [*, set.union_singleton] at h₂,
   apply h₁, exact ⟨sfalsumE h₂⟩
 end
 
 /- complete theories -/
-def is_complete (T : Theory L) := 
+def is_complete (T : Theory L) :=
 is_consistent T ∧ ∀(f : sentence L), f ∈ T ∨ ∼ f ∈ T
 
 def mem_of_sprf {T : Theory L} (H : is_complete T) {f : sentence L} (Hf : T ⊢ f) : f ∈ T :=
-begin 
+begin
   cases H.2 f, exact h, exfalso, apply H.1, constructor, refine impE _ _ Hf, apply saxm h
 end
 
@@ -2258,14 +2333,14 @@ begin
   cases H.2 f₁ with h h, { left, exact ⟨saxm h⟩ },
   cases H.2 f₂ with h' h', { right, exact ⟨saxm h'⟩ },
   exfalso, destruct H₂, intro H₂, apply H.1, constructor,
-  apply orE H₂; refine impE _ _ axm1; apply weakening1; apply axm; 
+  apply orE H₂; refine impE _ _ axm1; apply weakening1; apply axm;
     [exact mem_image_of_mem _ h, exact mem_image_of_mem _ h']
 end
 
 def impI_of_is_complete {T : Theory L} (H : is_complete T) {f₁ f₂ : sentence L}
   (H₂ : T ⊢' f₁ → T ⊢' f₂) : T ⊢' f₁ ⟹ f₂ :=
 begin
-  apply impI', cases H.2 f₁, 
+  apply impI', cases H.2 f₁,
   { apply weakening1', apply H₂, exact ⟨saxm h⟩ },
   apply falsumE', apply weakening1',
   apply impE' _ (weakening1' ⟨by apply saxm h⟩) ⟨axm1⟩
@@ -2279,18 +2354,18 @@ begin
 end
 
 def has_enough_constants (T : Theory L) :=
-∃(C : Π(f : bounded_formula L 1), L.constants), 
+∃(C : Π(f : bounded_formula L 1), L.constants),
 ∀(f : bounded_formula L 1), T ⊢' ∃' f ⟹ f[bd_const (C f)/0]
 
-lemma has_enough_constants.intro {L : Language} (T : Theory L) 
-  (H : ∀(f : bounded_formula L 1), ∃ c : L.constants, T ⊢' ∃' f ⟹ f[bd_const c/0]) : 
+lemma has_enough_constants.intro {L : Language} (T : Theory L)
+  (H : ∀(f : bounded_formula L 1), ∃ c : L.constants, T ⊢' ∃' f ⟹ f[bd_const c/0]) :
   has_enough_constants T :=
 classical.axiom_of_choice H
 
-def find_counterexample_of_henkin {T : Theory L} (H₁ : is_complete T) (H₂ : has_enough_constants T) 
+def find_counterexample_of_henkin {T : Theory L} (H₁ : is_complete T) (H₂ : has_enough_constants T)
   (f : bounded_formula L 1) (H₃ : ¬ T ⊢' ∀' f) : ∃(t : closed_term L), T ⊢' ∼ f[t/0] :=
 begin
-  induction H₂ with C HC, 
+  induction H₂ with C HC,
   refine ⟨bd_const (C (∼ f)), _⟩, dsimp [sprovable] at HC,
   apply (HC _).map2 (impE _),
   apply nonempty.map ex_not_of_not_all, apply notI_of_is_complete H₁ H₃
@@ -2299,7 +2374,7 @@ end
 variables (T : Theory L) (H₁ : is_complete T) (H₂ : has_enough_constants T)
 def term_rel (t₁ t₂ : closed_term L) : Prop := T ⊢' t₁ ≃ t₂
 
-def term_setoid : setoid $ closed_term L := 
+def term_setoid : setoid $ closed_term L :=
 ⟨term_rel T, λt, ⟨ref _ _⟩, λt t' H, H.map symm, λt₁ t₂ t₃ H₁ H₂, H₁.map2 trans H₂⟩
 local attribute [instance] term_setoid
 
@@ -2312,16 +2387,16 @@ quotient $ term_setoid T
 def term_model_fun' {l} (t : closed_preterm L l) (ts : dvector (closed_term L) l) : term_model' T :=
 @quotient.mk _ (term_setoid T) $ bd_apps t ts
 
--- def equal_preterms_trans {T : set (formula L)} : ∀{l} {t₁ t₂ t₃ : preterm L l} 
---   (h₁₂ : equal_preterms T t₁ t₂) (h₂₃ : equal_preterms T t₂ t₃), equal_preterms T t₁ t₃ 
+-- def equal_preterms_trans {T : set (formula L)} : ∀{l} {t₁ t₂ t₃ : preterm L l}
+--   (h₁₂ : equal_preterms T t₁ t₂) (h₂₃ : equal_preterms T t₂ t₃), equal_preterms T t₁ t₃
 
 variable {T}
 def term_model_fun_eq {l} (t t' : closed_preterm L (l+1)) (x x' : closed_term L)
-  (Ht : equal_preterms T.fst t.fst t'.fst) (Hx : T ⊢ x ≃ x') (ts : dvector (closed_term L) l) : 
+  (Ht : equal_preterms T.fst t.fst t'.fst) (Hx : T ⊢ x ≃ x') (ts : dvector (closed_term L) l) :
   term_model_fun' T (bd_app t x) ts = term_model_fun' T (bd_app t' x') ts :=
 begin
   induction ts generalizing x x',
-  { apply quotient.sound, refine ⟨trans (app_congr t.fst Hx) _⟩, apply Ht ([x'.fst]) }, 
+  { apply quotient.sound, refine ⟨trans (app_congr t.fst Hx) _⟩, apply Ht ([x'.fst]) },
   { apply ts_ih, apply equal_preterms_app Ht Hx, apply ref }
 end
 
@@ -2341,12 +2416,12 @@ T ⊢' bd_apps_rel f ts
 
 variable {T}
 def term_model_rel_iff {l} (f f' : presentence L (l+1)) (x x' : closed_term L)
-  (Ht : equiv_preformulae T.fst f.fst f'.fst) (Hx : T ⊢ x ≃ x') (ts : dvector (closed_term L) l) : 
+  (Ht : equiv_preformulae T.fst f.fst f'.fst) (Hx : T ⊢ x ≃ x') (ts : dvector (closed_term L) l) :
   term_model_rel' T (bd_apprel f x) ts ↔ term_model_rel' T (bd_apprel f' x') ts :=
 begin
   induction ts generalizing x x',
-  { apply iff.trans (apprel_congr' f.fst Hx), 
-    apply iff_of_biimp, have := Ht ([x'.fst]), exact ⟨this⟩ }, 
+  { apply iff.trans (apprel_congr' f.fst Hx),
+    apply iff_of_biimp, have := Ht ([x'.fst]), exact ⟨this⟩ },
   { apply ts_ih, apply equiv_preformulae_apprel Ht Hx, apply ref }
 end
 
@@ -2362,16 +2437,16 @@ begin
 end
 
 def term_model : Structure L :=
-⟨term_model' T, 
- λn, term_model_fun T ∘ bd_func, 
+⟨term_model' T,
+ λn, term_model_fun T ∘ bd_func,
  λn, term_model_rel T ∘ bd_rel⟩
 
 @[reducible] def term_mk : closed_term L → term_model T :=
 @quotient.mk _ $ term_setoid T
 
--- lemma realize_bounded_preterm_term_model {l n} (ts : dvector (closed_term L) l) 
+-- lemma realize_bounded_preterm_term_model {l n} (ts : dvector (closed_term L) l)
 --   (t : bounded_preterm L l n) (ts' : dvector (closed_term L) n) :
---   realize_bounded_term (ts.map term_mk) t (ts'.map term_mk) = 
+--   realize_bounded_term (ts.map term_mk) t (ts'.map term_mk) =
 --   (term_mk _) :=
 -- begin
 --   induction t with t ht,
@@ -2379,14 +2454,14 @@ def term_model : Structure L :=
 -- end
 
 variable {T}
-lemma realize_closed_preterm_term_model {l} (ts : dvector (closed_term L) l) (t : closed_preterm L l) : 
+lemma realize_closed_preterm_term_model {l} (ts : dvector (closed_term L) l) (t : closed_preterm L l) :
   realize_bounded_term ([]) t (ts.map $ term_mk T) = (term_mk T (bd_apps t ts)) :=
 begin
   induction t,
   { apply t.fin_zero_elim },
   { apply dvector.quotient_beta },
   { rw [realize_bounded_term_bd_app],
-    have := t_ih_s ([]), dsimp at this, rw this, 
+    have := t_ih_s ([]), dsimp at this, rw this,
     apply t_ih_t (t_s::ts) }
 end
 
@@ -2398,11 +2473,11 @@ by apply realize_closed_preterm_term_model ([]) t
 --   revert t, refine bounded_term.rec _ _; intros,
 --   { apply k.fin_zero_elim },
 --   --{ apply dvector.quotient_beta },
---   { 
-    
+--   {
+
 --     --exact dvector.quotient_beta _ _ ts,
 --     rw [realize_bounded_term_bd_app],
---     have := t_ih_s ([]), dsimp at this, rw this, 
+--     have := t_ih_s ([]), dsimp at this, rw this,
 --     apply t_ih_t (t_s::ts) }
 -- end
 
@@ -2412,18 +2487,18 @@ lemma realize_subst_preterm {S : Structure L} {n l} (t : bounded_preterm L (n+1)
   realize_bounded_term v (substmax_bounded_term t s) xs =
   realize_bounded_term (v.concat (realize_closed_term S s)) t xs :=
 begin
-  induction t, 
+  induction t,
   { by_cases h : t.1 < n,
     { rw [substmax_var_lt t s h], dsimp,
       simp only [dvector.map_nth, dvector.concat_nth _ _ _ _ h] },
     { have h' := le_antisymm (le_of_lt_succ t.2) (le_of_not_gt h), simp [h'],
-      rw [substmax_var_eq t s h'], 
+      rw [substmax_var_eq t s h'],
       apply realize_bounded_term_irrel, simp }},
-  { refl }, 
+  { refl },
   { dsimp, rw [substmax_bounded_term_bd_app], dsimp, rw [t_ih_s ([]), t_ih_t] }
 end
 
-lemma realize_subst_term {S : Structure L} {n} (v : dvector S n) (s : closed_term L) 
+lemma realize_subst_term {S : Structure L} {n} (v : dvector S n) (s : closed_term L)
   (t : bounded_term L (n+1))  :
   realize_bounded_term v (substmax_bounded_term t s) ([]) =
   realize_bounded_term (v.concat (realize_closed_term S s)) t ([]) :=
@@ -2437,9 +2512,9 @@ begin
   revert n f v, refine bounded_formula.rec1 _ _ _ _ _; intros,
   { simp },
   { apply eq.congr, exact realize_subst_term v t t₁, exact realize_subst_term v t t₂ },
-  { rw [substmax_bounded_formula_bd_apps_rel, realize_bounded_formula_bd_apps_rel, 
-        realize_bounded_formula_bd_apps_rel], 
-    simp [ts.map_congr (realize_subst_term _ _)] }, 
+  { rw [substmax_bounded_formula_bd_apps_rel, realize_bounded_formula_bd_apps_rel,
+        realize_bounded_formula_bd_apps_rel],
+    simp [ts.map_congr (realize_subst_term _ _)] },
   { apply imp_congr, apply ih₁ v, apply ih₂ v },
   { simp, apply forall_congr, intro x, apply ih (x::v) }
 end
@@ -2459,18 +2534,18 @@ begin
 end
 
 include H₁
-def term_model_ssatisfied_iff {n} : ∀{l} (f : presentence L l) 
+def term_model_ssatisfied_iff {n} : ∀{l} (f : presentence L l)
   (ts : dvector (closed_term L) l) (h : count_quantifiers f.fst < n),
   T ⊢' bd_apps_rel f ts ↔ term_model T ⊨ bd_apps_rel f ts :=
 begin
   refine nat.strong_induction_on n _, clear n,
   intros n n_ih l f ts hn,
-  have : {f' : preformula L l // f.fst = f' } := ⟨f.fst, rfl⟩, 
+  have : {f' : preformula L l // f.fst = f' } := ⟨f.fst, rfl⟩,
   cases this with f' hf, induction f'; cases f; injection hf with hf₁ hf₂,
   { simp, exact H₁.1.elim },
   { simp, refine iff.trans _ (realize_sentence_equal f_t₁ f_t₂).symm, simp [term_mk], refl },
-  { refine iff.trans _ (realize_bd_apps_rel _ _).symm, 
-    dsimp [term_model, term_model_rel], 
+  { refine iff.trans _ (realize_bd_apps_rel _ _).symm,
+    dsimp [term_model, term_model_rel],
     rw [ts.map_congr realize_closed_term_term_model, dvector.quotient_beta], refl },
   { apply f'_ih f_f (f_t::ts) _ hf₁, simp at hn ⊢, exact hn },
   { have ih₁ := f'_ih_f₁ f_f₁ ([]) (lt_of_le_of_lt (nat.le_add_right _ _) hn) hf₁,
@@ -2481,7 +2556,7 @@ begin
       exact impI_of_is_complete H₁ h }},
   { cases ts, split; intro h,
     { simp at h ⊢,
-      apply quotient.ind, intro t, 
+      apply quotient.ind, intro t,
       apply (term_model_subst0 f_f t).mp,
       cases n with n, { exfalso, exact not_lt_zero _ hn },
       refine (n_ih n (lt.base n) (f_f[t/0]) ([]) _).mp (h.map _),
@@ -2506,7 +2581,7 @@ end
 lemma completeness' {f : sentence L} (H : T ⊨ f) : T ⊢' f :=
 begin
   apply (term_model_ssatisfied_iff H₁ H₂ f ([]) (lt.base _)).mpr,
-  apply H, exact fol.nonempty_term_model H₂, 
+  apply H, exact fol.nonempty_term_model H₂,
   apply term_model_ssatisfied H₁ H₂,
 end
 omit H₁ H₂


### PR DESCRIPTION
This is still a work in progress, it doesn't build, but I want to put this out early so as to head off any duplicate work and possibly inspire further work. I have added `dfin` with a bunch of lemmas and constructions, and I also add a predicate `is_bounded_preterm` alongside (not replacing) `bounded_preterm`. But I think many of the more advanced operations like lift and subst need not exist on bounded preterms, in lieu of theorems that state that bounds are preserved.