### PR TITLE
synchronize with lean-depot snapshot

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,4 +5,4 @@ lean_version = "3.4.2"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "4bb8d4475f897c8997100d31fe84b33050444374"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "94e368c5025c8e888da89c5bfc326c88d05f9496"}

--- a/src/bvm.lean
+++ b/src/bvm.lean
@@ -2497,7 +2497,7 @@ theorem bSet_zorns_lemma (X : bSet 𝔹) (H_nonempty : -(X =ᴮ ∅) = ⊤) (H :
   ⊤ ≤ (⨆c, c ∈ᴮ X ⊓ (⨅z, z ∈ᴮ X ⟹ (c ⊆ᴮ z ⟹ c =ᴮ z))) :=
 begin
   have := core.mk X, rcases this with ⟨α, ⟨S, h_core⟩⟩,
-  have H_zorn := zorn (subset'_inductive X H h_core) (by apply subset'_trans),
+  have H_zorn := exists_maximal_of_chains_bounded (subset'_inductive X H h_core) (by apply subset'_trans),
   rcases H_zorn with ⟨c, H_c⟩, rcases h_core with ⟨h_core_l, h_core_r⟩,
   have H_c_in_X := h_core_l c, apply bv_use (S c), rw[H_c_in_X],
   rw[top_inf_eq], bv_intro x, apply bv_imp_intro, rw[top_inf_eq],


### PR DESCRIPTION
Made small modification to work with the latest version of mathlib picked by lean-depot. 

If this is satisfactory, please merge and use a pull request to adjust the commit in https://gitlab.com/simon.hudon/lean-depot/blob/master/pkgs/flypitch.toml