### PR TITLE
Cope with the upstream Lean 3 repository rename.

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flypitch"
 version = "2.2"
-lean_version = "3.4.2"
+lean_version = "leanprover/lean3:3.4.2"
 path = "src"
 
 [dependencies]


### PR DESCRIPTION
Previously trying to run this (with newer elans) would say there was no binary package for Linux, seemingly because it was trying against leanprover/lean and not following the redirect, but this seems to work now here (for me in Gitpod) after this change.